### PR TITLE
Image creation timestamp fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,7 @@
 							<author>SNOMED International &lt;tooling@snomed.org&gt;</author>
 						</labels>
 						<mainClass>org.snomed.snowstormlite.SnowstormLiteApplication</mainClass>
+						<creationTime>USE_CURRENT_TIMESTAMP</creationTime>
 						<environment>
 							<application.title>${project.name}</application.title>
 							<application.version>${project.version}</application.version>


### PR DESCRIPTION
- As per https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin, we have to use `creationTime` to set creation timestamp.