### PR TITLE
Add optional embedding-powered semantic search

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "snowstorm-lite-dev",
+  "image": "snowstorm-lite-devcontainer:poc",
+  "overrideCommand": true,
+  "workspaceFolder": "/workspaces/snowstorm-lite",
+  "postCreateCommand": "mvn -q -DskipTests test-compile",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "redhat.vscode-xml"
+      ],
+      "settings": {
+        "java.configuration.updateBuildConfiguration": "interactive"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 .*
+!.devcontainer/
+!.devcontainer/devcontainer.json
 target
 lucene-index
+full-lucene-index
 test-lucene-index
+__pycache__
 application.properties
 application*.properties

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,10 @@ A fast FHIR Terminology Server for SNOMED CT with a small memory footprint.
 - FHIR Terminology Operations
   - CodeSystem lookup
     - Including parents, children, designations, normal form
+  - Embedding-powered semantic search (optional, requires `snowstorm.embeddings.enabled=true`)
+    - Index user-provided concept embeddings with `CodeSystem/$index-embeddings`
+    - High-throughput binary indexing with `CodeSystem/$index-embeddings-binary` (`application/octet-stream`)
+    - Query semantic matches within ECL constraints using `ValueSet/$expand` (`_semantic=true`) or `CodeSystem/$semantic-match`
   - ValueSet expand using [SNOMED CT Implicit Value Sets](http://hl7.org/fhir/R4/snomedct.html#implicit)
     - SNOMED CT `isa` and `ecl` filters are supported
   - ConceptMap translate using [SNOMED CT Implicit Maps](http://hl7.org/fhir/R4/snomedct.html#implicit-cm)
@@ -95,6 +99,38 @@ When the import is complete Snowstorm Lite will be ready for use! The FHIR inter
 It is possible to [import extension or derivative packages](docs/importing-extension-or-derivative-packages.md).
 
 _It is also possible to [deploy as a Java application, without Docker](docs/running-with-java.md)._
+
+### High-throughput embedding ingestion
+For large embedding runs, use the binary operation:
+
+`POST /fhir/CodeSystem/$index-embeddings-binary?model={modelId}&replace={true|false}`
+
+Payload format is little-endian:
+- 4 bytes magic: `SLE1`
+- `int32` vector dimension
+- `int32` record count
+- repeated records:
+  - `uint64` concept id
+  - `float32[dimension]` vector values
+
+A Python helper script for generating and indexing embeddings from RF2 files is available in the
+[snowstorm-mcp-server examples](https://github.com/nicgirault/snowstorm-mcp-server/tree/main/examples/embedding-indexer).
+
+### Feature discovery endpoint
+Snowstorm Lite exposes a non-FHIR feature advertisement endpoint:
+
+`GET /fhir-admin/features`
+
+This endpoint returns JSON containing explicit capability flags, including:
+- `embeddingsSupported`
+- `semanticSearchSupported`
+- `features.semanticExpand`
+- `features.semanticMatchOperation`
+- `features.embeddingIndexOperation`
+- `features.embeddingBinaryIndexOperation`
+- `features.semanticSearchWithinEcl`
+
+This endpoint is intended for clients such as MCP servers to detect optional capabilities without probing operation failures.
 
 ## Postman
 This Postman collection allows you to try the various API functions of the Snowstorm Lite server. It's similar to a Swagger UI.  

--- a/src/main/java/org/snomed/snowstormlite/config/BasicAuthWebSecurityConfiguration.java
+++ b/src/main/java/org/snomed/snowstormlite/config/BasicAuthWebSecurityConfiguration.java
@@ -33,6 +33,7 @@ public class BasicAuthWebSecurityConfiguration {
 						.requestMatchers(HttpMethod.POST, "/fhir/ValueSet").authenticated()
 						.requestMatchers(HttpMethod.PUT, "/fhir/ValueSet").authenticated()
 						.requestMatchers(HttpMethod.DELETE, "/fhir/ValueSet").authenticated()
+						.requestMatchers(HttpMethod.GET, "/fhir-admin/features").permitAll()
 						.requestMatchers("/fhir/**").permitAll()
 						.requestMatchers("/*").permitAll()
 						.requestMatchers("/_ah/warmup").permitAll()

--- a/src/main/java/org/snomed/snowstormlite/fhir/AdminController.java
+++ b/src/main/java/org/snomed/snowstormlite/fhir/AdminController.java
@@ -5,8 +5,12 @@ import ca.uhn.fhir.parser.IParser;
 import jakarta.servlet.http.HttpServletResponse;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.ihtsdo.otf.snomedboot.ReleaseImportException;
+import org.snomed.snowstormlite.service.CodeSystemRepository;
+import org.snomed.snowstormlite.service.EmbeddingIndexService;
 import org.snomed.snowstormlite.snomedimport.ImportService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,7 +20,9 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -29,6 +35,47 @@ public class AdminController {
 
 	@Autowired
 	private FhirContext fhirContext;
+
+	@Autowired(required = false)
+	private BuildProperties buildProperties;
+
+	@Autowired
+	private CodeSystemRepository codeSystemRepository;
+
+	@Autowired(required = false)
+	private EmbeddingIndexService embeddingIndexService;
+
+	@GetMapping("features")
+	public Map<String, Object> features() {
+		boolean embeddingsEnabled = embeddingIndexService != null;
+
+		Map<String, Object> response = new LinkedHashMap<>();
+		response.put("schemaVersion", 1);
+		response.put("product", "snowstorm-lite");
+		response.put("version", buildProperties != null ? buildProperties.getVersion() : "development");
+		response.put("embeddingsSupported", embeddingsEnabled);
+		response.put("semanticSearchSupported", embeddingsEnabled);
+		response.put("codeSystemLoaded", codeSystemRepository.getCodeSystem() != null);
+
+		Map<String, Object> featureFlags = new LinkedHashMap<>();
+		featureFlags.put("semanticExpand", embeddingsEnabled);
+		featureFlags.put("semanticMatchOperation", embeddingsEnabled);
+		featureFlags.put("embeddingIndexOperation", embeddingsEnabled);
+		featureFlags.put("embeddingBinaryIndexOperation", embeddingsEnabled);
+		featureFlags.put("semanticSearchWithinEcl", embeddingsEnabled);
+		response.put("features", featureFlags);
+
+		if (embeddingsEnabled) {
+			Map<String, Object> operations = new LinkedHashMap<>();
+			operations.put("semanticExpand", "GET|POST /fhir/ValueSet/$expand?_semantic=true");
+			operations.put("semanticMatch", "GET|POST /fhir/CodeSystem/$semantic-match");
+			operations.put("indexEmbeddings", "POST /fhir/CodeSystem/$index-embeddings");
+			operations.put("indexEmbeddingsBinary", "POST /fhir/CodeSystem/$index-embeddings-binary");
+			response.put("operations", operations);
+		}
+
+		return response;
+	}
 
 	@PostMapping(value = "load-package", consumes = "multipart/form-data")
 	public void loadPackage(@RequestParam(name = "version-uri") String versionUri, @RequestParam MultipartFile[] file, HttpServletResponse response) throws IOException {

--- a/src/main/java/org/snomed/snowstormlite/fhir/CodeSystemProvider.java
+++ b/src/main/java/org/snomed/snowstormlite/fhir/CodeSystemProvider.java
@@ -1,5 +1,6 @@
 package org.snomed.snowstormlite.fhir;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.annotation.*;
 import ca.uhn.fhir.rest.param.StringAndListParam;
 import ca.uhn.fhir.rest.server.IResourceProvider;
@@ -8,17 +9,18 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.hl7.fhir.r4.model.*;
 import org.snomed.snowstormlite.domain.FHIRCodeSystem;
 import org.snomed.snowstormlite.domain.LanguageDialect;
-import org.snomed.snowstormlite.service.CodeSystemRepository;
-import org.snomed.snowstormlite.service.CodeSystemService;
+import org.snomed.snowstormlite.service.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 
 import static java.lang.String.format;
-import static org.snomed.snowstormlite.fhir.FHIRConstants.ACCEPT_LANGUAGE_HEADER;
+import static org.snomed.snowstormlite.fhir.FHIRConstants.*;
 import static org.snomed.snowstormlite.fhir.FHIRHelper.*;
 
 @Component
@@ -32,6 +34,15 @@ public class CodeSystemProvider implements IResourceProvider {
 
 	@Autowired
 	private LanguageDialectParser languageDialectParser;
+
+	@Autowired
+	private ValueSetService valueSetService;
+
+	@Autowired(required = false)
+	private EmbeddingIndexService embeddingIndexService;
+
+	@Autowired
+	private FhirContext fhirContext;
 
 	@Search
 	public List<CodeSystem> findCodeSystems(
@@ -69,17 +80,17 @@ public class CodeSystemProvider implements IResourceProvider {
 		return null;
 	}
 
-	@Operation(name="$lookup", idempotent=true)
+	@Operation(name = "$lookup", idempotent = true)
 	public Parameters lookupImplicit(
 			HttpServletRequest request,
 			HttpServletResponse response,
-			@OperationParam(name="code") CodeType code,
-			@OperationParam(name="system") UriType system,
-			@OperationParam(name="version") StringType version,
-			@OperationParam(name="coding") Coding coding,
-			@OperationParam(name="date") StringType date,
-			@OperationParam(name="displayLanguage") String displayLanguage,
-			@OperationParam(name="property") List<CodeType> propertiesType ) {
+			@OperationParam(name = "code") CodeType code,
+			@OperationParam(name = "system") UriType system,
+			@OperationParam(name = "version") StringType version,
+			@OperationParam(name = "coding") Coding coding,
+			@OperationParam(name = "date") StringType date,
+			@OperationParam(name = "displayLanguage") String displayLanguage,
+			@OperationParam(name = "property") List<CodeType> propertiesType) {
 
 		mutuallyExclusive("code", code, "coding", coding);
 		notSupported("date", date);
@@ -88,31 +99,150 @@ public class CodeSystemProvider implements IResourceProvider {
 		return codeSystemService.lookup(codeSystem, recoverCode(code, coding), languageDialects);
 	}
 
-	@Operation(name="$subsumes", idempotent=true)
+	@Operation(name = "$subsumes", idempotent = true)
 	public Parameters subsumes(
 			HttpServletRequest request,
 			HttpServletResponse response,
-			@OperationParam(name="codeA") CodeType codeA,
-			@OperationParam(name="codeB") CodeType codeB,
-			@OperationParam(name="system") UriType system,
-			@OperationParam(name="version") StringType version,
-			@OperationParam(name="codingA") Coding codingA,
-			@OperationParam(name="codingB") Coding codingB,
-			@OperationParam(name="date") StringType date) {
+			@OperationParam(name = "codeA") CodeType codeA,
+			@OperationParam(name = "codeB") CodeType codeB,
+			@OperationParam(name = "system") UriType system,
+			@OperationParam(name = "version") StringType version,
+			@OperationParam(name = "codingA") Coding codingA,
+			@OperationParam(name = "codingB") Coding codingB,
+			@OperationParam(name = "date") StringType date) {
 
 		// Validate parameters
 		requireExactlyOneOf("codeA", codeA, "codingA", codingA);
 		requireExactlyOneOf("codeB", codeB, "codingB", codingB);
 		notSupported("date", date);
-		
+
 		// Get code system
 		FHIRCodeSystem codeSystem = getCodeSystemVersionOrThrow(system, version, codingA != null ? codingA : codingB);
-		
+
 		// Extract codes
 		String codeAValue = recoverCode(codeA, codingA);
 		String codeBValue = recoverCode(codeB, codingB);
-		
+
 		return codeSystemService.subsumes(codeSystem, codeAValue, codeBValue);
+	}
+
+	@Operation(name = "$index-embeddings", idempotent = false)
+	public Parameters indexEmbeddings(
+			@ResourceParam String rawBody,
+			@OperationParam(name = "model") String modelParam,
+			@OperationParam(name = "replace") BooleanType replaceType) {
+
+		requireEmbeddingsEnabled();
+		Parameters requestParameters = parseParametersBody(rawBody);
+		String modelId = embeddingIndexService.resolveModelId(firstStringValue(requestParameters, "model").orElse(modelParam));
+		boolean replace = replaceType != null ? replaceType.booleanValue() : firstBooleanValue(requestParameters, "replace").orElse(false);
+
+		List<EmbeddingIndexService.EmbeddingInput> embeddingInputs = new ArrayList<>();
+		for (Parameters.ParametersParameterComponent parameter : requestParameters.getParameter()) {
+			if ("embedding".equals(parameter.getName())) {
+				String code = requiredPartValue(parameter, "code");
+				String vectorText = requiredPartValue(parameter, "vector");
+				embeddingInputs.add(new EmbeddingIndexService.EmbeddingInput(code, embeddingIndexService.parseVector(vectorText, "embedding.vector")));
+			}
+		}
+		if (embeddingInputs.isEmpty()) {
+			throw exception("At least one 'embedding' parameter is required.", OperationOutcome.IssueType.REQUIRED, 400);
+		}
+
+		try {
+			int indexed = embeddingIndexService.indexEmbeddings(modelId, embeddingInputs, replace);
+			Parameters response = new Parameters();
+			response.addParameter("result", true);
+			response.addParameter("model", modelId);
+			response.addParameter("replace", replace);
+			response.addParameter("indexed", indexed);
+			return response;
+		} catch (IOException e) {
+			throw exception("Failed to index embeddings.", OperationOutcome.IssueType.EXCEPTION, 500, e);
+		}
+	}
+
+	@Operation(name = "$index-embeddings-binary", idempotent = false, manualRequest = true)
+	public Parameters indexEmbeddingsBinary(
+			HttpServletRequest request,
+			@OperationParam(name = "model") String modelParam,
+			@OperationParam(name = "replace") BooleanType replaceType) {
+
+		requireEmbeddingsEnabled();
+		String modelId = embeddingIndexService.resolveModelId(modelParam != null ? modelParam : request.getParameter("model"));
+		Boolean replaceFromQuery = parseBooleanQueryParam(request.getParameter("replace"), "replace");
+		boolean replace = replaceType != null ? replaceType.booleanValue() : replaceFromQuery != null && replaceFromQuery;
+
+		String contentType = request.getContentType();
+		if (contentType != null && !contentType.toLowerCase(Locale.ROOT).startsWith("application/octet-stream")) {
+			throw exception(
+					"Binary embedding indexing requires content type 'application/octet-stream'.",
+					OperationOutcome.IssueType.INVALID,
+					400);
+		}
+
+		List<EmbeddingIndexService.EmbeddingInput> embeddingInputs = embeddingIndexService.parseBinaryEmbeddings(getRequestInputStream(request));
+		try {
+			int indexed = embeddingIndexService.indexEmbeddings(modelId, embeddingInputs, replace);
+			Parameters response = new Parameters();
+			response.addParameter("result", true);
+			response.addParameter("model", modelId);
+			response.addParameter("replace", replace);
+			response.addParameter("indexed", indexed);
+			return response;
+		} catch (IOException e) {
+			throw exception("Failed to index binary embeddings.", OperationOutcome.IssueType.EXCEPTION, 500, e);
+		}
+	}
+
+	@Operation(name = "$semantic-match", idempotent = true)
+	public Parameters semanticMatch(
+			HttpServletRequest request,
+			@OperationParam(name = "text") String text,
+			@OperationParam(name = "vector") String vector,
+			@OperationParam(name = "ecl") String ecl,
+			@OperationParam(name = "count") IntegerType countType,
+			@OperationParam(name = "offset") IntegerType offsetType,
+			@OperationParam(name = "model") String model,
+			@OperationParam(name = "displayLanguage") String displayLanguage) {
+
+		requireEmbeddingsEnabled();
+		int count = countType != null ? countType.getValue() : 20;
+		int offset = offsetType != null ? offsetType.getValue() : 0;
+		String modelId = embeddingIndexService.resolveModelId(model);
+		float[] queryVector = embeddingIndexService.parseVector(vector, "vector");
+		SemanticQueryRequest semanticQuery = SemanticQueryRequest.enabled(modelId, queryVector);
+		String valueSetUrl = (ecl == null || ecl.isBlank()) ? IMPLICIT_EVERYTHING : SNOMED_URI + IMPLICIT_ECL + ecl;
+
+		List<LanguageDialect> languageDialects = languageDialectParser.parseDisplayLanguageWithDefaultFallback(
+				displayLanguage, request.getHeader(ACCEPT_LANGUAGE_HEADER));
+		try {
+			ValueSet semanticExpansion = valueSetService.expand(valueSetUrl, text, languageDialects, false, offset, count, semanticQuery);
+			Parameters response = new Parameters();
+			response.addParameter("result", true);
+			response.addParameter("model", modelId);
+			response.addParameter("offset", offset);
+			response.addParameter("count", count);
+			response.addParameter("total", semanticExpansion.getExpansion().getTotal());
+			for (ValueSet.ValueSetExpansionContainsComponent containsComponent : semanticExpansion.getExpansion().getContains()) {
+				Parameters.ParametersParameterComponent match = response.addParameter().setName("match");
+				match.addPart().setName("code").setValue(new CodeType(containsComponent.getCode()));
+				match.addPart().setName("display").setValue(new StringType(containsComponent.getDisplay()));
+				containsComponent.getExtensionsByUrl(ValueSetService.SEMANTIC_SCORE_EXTENSION_URL).stream()
+						.findFirst()
+						.ifPresent(extension -> match.addPart().setName("score").setValue(extension.getValue()));
+			}
+			return response;
+		} catch (IOException e) {
+			throw exception("Failed to execute semantic search.", OperationOutcome.IssueType.EXCEPTION, 500, e);
+		}
+	}
+
+	private void requireEmbeddingsEnabled() {
+		if (embeddingIndexService == null) {
+			throw exception("Embedding support is not enabled. Set 'snowstorm.embeddings.enabled=true' in application configuration.",
+					OperationOutcome.IssueType.NOTSUPPORTED, 501);
+		}
 	}
 
 	private FHIRCodeSystem getCodeSystemVersionOrThrow(UriType system, StringType version, Coding coding) {
@@ -124,6 +254,67 @@ public class CodeSystemProvider implements IResourceProvider {
 		throw exception(format("Code system not found for parameters %s.", codeSystemVersionParams), OperationOutcome.IssueType.NOTFOUND, 404);
 	}
 
+	private Parameters parseParametersBody(String rawBody) {
+		if (rawBody == null || rawBody.isBlank()) {
+			throw exception("Parameters payload is required.", OperationOutcome.IssueType.REQUIRED, 400);
+		}
+		try {
+			return fhirContext.newJsonParser().parseResource(Parameters.class, rawBody);
+		} catch (Exception e) {
+			throw exception("Unable to parse Parameters payload.", OperationOutcome.IssueType.INVALID, 400, e);
+		}
+	}
+
+	private Optional<String> firstStringValue(Parameters parameters, String name) {
+		return parameters.getParameter().stream()
+				.filter(parameter -> name.equals(parameter.getName()) && parameter.getValue() instanceof PrimitiveType<?> )
+				.map(parameter -> ((PrimitiveType<?>) parameter.getValue()).getValueAsString())
+				.filter(value -> value != null && !value.isBlank())
+				.findFirst();
+	}
+
+	private Optional<Boolean> firstBooleanValue(Parameters parameters, String name) {
+		return parameters.getParameter().stream()
+				.filter(parameter -> name.equals(parameter.getName()) && parameter.getValue() instanceof BooleanType)
+				.map(parameter -> ((BooleanType) parameter.getValue()).booleanValue())
+				.findFirst();
+	}
+
+	private String requiredPartValue(Parameters.ParametersParameterComponent parameter, String partName) {
+		return parameter.getPart().stream()
+				.filter(part -> partName.equals(part.getName()) && part.getValue() instanceof PrimitiveType<?> )
+				.map(part -> ((PrimitiveType<?>) part.getValue()).getValueAsString())
+				.filter(value -> value != null && !value.isBlank())
+				.findFirst()
+				.orElseThrow(() -> exception(
+						format("Each embedding parameter must include non-empty part '%s'.", partName),
+						OperationOutcome.IssueType.INVALID,
+						400));
+	}
+
+	private Boolean parseBooleanQueryParam(String value, String parameterName) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		if ("true".equalsIgnoreCase(value)) {
+			return true;
+		}
+		if ("false".equalsIgnoreCase(value)) {
+			return false;
+		}
+		throw exception(
+				format("Parameter '%s' must be 'true' or 'false'.", parameterName),
+				OperationOutcome.IssueType.INVALID,
+				400);
+	}
+
+	private java.io.InputStream getRequestInputStream(HttpServletRequest request) {
+		try {
+			return request.getInputStream();
+		} catch (IOException e) {
+			throw exception("Unable to read request body.", OperationOutcome.IssueType.INVALID, 400, e);
+		}
+	}
 
 	@Override
 	public Class<CodeSystem> getResourceType() {

--- a/src/main/java/org/snomed/snowstormlite/fhir/ValueSetProvider.java
+++ b/src/main/java/org/snomed/snowstormlite/fhir/ValueSetProvider.java
@@ -13,6 +13,8 @@ import org.snomed.snowstormlite.domain.FHIRDescription;
 import org.snomed.snowstormlite.domain.LanguageDialect;
 import org.snomed.snowstormlite.domain.valueset.FHIRValueSet;
 import org.snomed.snowstormlite.service.CodeSystemRepository;
+import org.snomed.snowstormlite.service.EmbeddingIndexService;
+import org.snomed.snowstormlite.service.SemanticQueryRequest;
 import org.snomed.snowstormlite.service.ValueSetService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.util.Pair;
@@ -46,6 +48,9 @@ public class ValueSetProvider implements IResourceProvider {
 
 	@Autowired
 	private CodeSystemRepository codeSystemRepository;
+
+	@Autowired(required = false)
+	private EmbeddingIndexService embeddingIndexService;
 
 	@Search
 	public List<ValueSet> search(
@@ -134,6 +139,9 @@ public class ValueSetProvider implements IResourceProvider {
 			@OperationParam(name="excludeNotForUI") BooleanType excludeNotForUI,
 			@OperationParam(name="excludePostCoordinated") BooleanType excludePostCoordinated,
 			@OperationParam(name="displayLanguage") String displayLanguage,
+			@OperationParam(name="_semantic") BooleanType semanticType,
+			@OperationParam(name="semanticModel") String semanticModel,
+			@OperationParam(name="semanticVector") String semanticVector,
 			@OperationParam(name="exclude-system") StringType excludeSystem,
 			@OperationParam(name="system-version") StringType systemVersion,
 			@OperationParam(name="check-system-version") StringType checkSystemVersion,
@@ -152,8 +160,9 @@ public class ValueSetProvider implements IResourceProvider {
 		parameterNamingHint("version", version, "system-version");
 
 		int count = countType != null ? countType.getValue() : 100;
+		SemanticQueryRequest semanticQuery = buildSemanticQuery(semanticType, semanticModel, semanticVector);
 
-		return doExpand(request, rawBody, id, url, filter, offset, includeDesignationsType, displayLanguage, count, null).getFirst();
+		return doExpand(request, rawBody, id, url, filter, offset, includeDesignationsType, displayLanguage, count, null, semanticQuery).getFirst();
 	}
 
 	@Operation(name="$validate-code", idempotent=true)
@@ -206,7 +215,7 @@ public class ValueSetProvider implements IResourceProvider {
 
 		// Resolve and expand the ValueSet with the requested codes
 		Pair<ValueSet, List<FHIRConcept>> expandedValueSetAndConceptPage = doExpand(request, rawBody, id, url, null, new IntegerType(0),
-				includeDesignations, displayLanguage, codingsToValidate.size(), codingsToValidate);
+				includeDesignations, displayLanguage, codingsToValidate.size(), codingsToValidate, SemanticQueryRequest.disabled());
 		List<FHIRConcept> expandedConcepts = expandedValueSetAndConceptPage.getSecond();
 
 		Parameters response = new Parameters();
@@ -318,7 +327,8 @@ public class ValueSetProvider implements IResourceProvider {
 	}
 
 	private Pair<ValueSet, List<FHIRConcept>> doExpand(HttpServletRequest request, String rawBody, IdType id, UriType url,
-			String filter, IntegerType offset, BooleanType includeDesignationsType, String displayLanguage, int count, Set<Coding> codingsToValidate) {
+			String filter, IntegerType offset, BooleanType includeDesignationsType, String displayLanguage, int count,
+			Set<Coding> codingsToValidate, SemanticQueryRequest semanticQuery) {
 
 		ValueSet postedValueSet = null;
 		List<String> requestedProperties = Collections.emptyList();
@@ -339,10 +349,27 @@ public class ValueSetProvider implements IResourceProvider {
 				throw FHIRHelper.exception("ValueSet not found.", OperationOutcome.IssueType.NOTFOUND, 404);
 			}
 			return valueSetService.expand(new FHIRValueSet(valueSet), filter, languageDialects, toBool(includeDesignationsType),
-					requestedProperties, offset != null ? offset.getValue() : 0, count, codingsToValidate);
+					requestedProperties, offset != null ? offset.getValue() : 0, count, codingsToValidate, semanticQuery);
 		} catch (IOException e) {
 			throw FHIRHelper.exceptionWithErrorLogging("Failed to expand ValueSet " + (url != null ? url : id), OperationOutcome.IssueType.EXCEPTION, 500, e);
 		}
+	}
+
+	private SemanticQueryRequest buildSemanticQuery(BooleanType semanticType, String semanticModel, String semanticVector) {
+		boolean semantic = semanticType != null && semanticType.booleanValue();
+		if (!semantic) {
+			if (semanticModel != null || semanticVector != null) {
+				throw exception("Parameters 'semanticModel' and 'semanticVector' require '_semantic=true'.", OperationOutcome.IssueType.INVALID, 400);
+			}
+			return SemanticQueryRequest.disabled();
+		}
+		if (embeddingIndexService == null) {
+			throw exception("Semantic search is not enabled. Set 'snowstorm.embeddings.enabled=true' in application configuration.",
+					OperationOutcome.IssueType.NOTSUPPORTED, 501);
+		}
+		return SemanticQueryRequest.enabled(
+				embeddingIndexService.resolveModelId(semanticModel),
+				embeddingIndexService.parseVector(semanticVector, "semanticVector"));
 	}
 
 	private boolean toBool(BooleanType bool) {

--- a/src/main/java/org/snomed/snowstormlite/service/EmbeddingIndexService.java
+++ b/src/main/java/org/snomed/snowstormlite/service/EmbeddingIndexService.java
@@ -1,0 +1,297 @@
+package org.snomed.snowstormlite.service;
+
+import org.apache.lucene.document.*;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.*;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.snomed.snowstormlite.fhir.FHIRHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+import static java.lang.String.format;
+
+@Service
+@ConditionalOnProperty(name = "snowstorm.embeddings.enabled", havingValue = "true")
+public class EmbeddingIndexService {
+
+	public static final String DEFAULT_MODEL_ID = "default";
+	private static final String DOC_TYPE = "concept_embedding";
+	private static final String MODEL_ID = "embedding_model";
+	private static final String CONCEPT_ID = "concept_id";
+	private static final String VECTOR_FIELD_PREFIX = "embedding_vector_";
+	private static final byte[] BINARY_MAGIC = new byte[]{'S', 'L', 'E', '1'};
+	private static final int MAX_VECTOR_DIMENSION = 4096;
+	private static final int MAX_BINARY_BATCH_SIZE = 200_000;
+
+	@Autowired
+	private IndexIOProvider indexIOProvider;
+
+	public record EmbeddingInput(String conceptId, float[] vector) {}
+
+	public record SemanticMatch(String conceptId, float score) {}
+
+	public record SemanticSearchResult(long totalHits, List<SemanticMatch> matches) {}
+
+	public synchronized int indexEmbeddings(String modelId, List<EmbeddingInput> embeddings, boolean replaceModel) throws IOException {
+		String resolvedModelId = resolveModelId(modelId);
+		if (embeddings == null || embeddings.isEmpty()) {
+			throw FHIRHelper.exception("At least one embedding must be supplied.", OperationOutcome.IssueType.REQUIRED, 400);
+		}
+
+		Map<String, float[]> vectorsByConcept = new LinkedHashMap<>();
+		int dimension = -1;
+		for (EmbeddingInput embedding : embeddings) {
+			if (embedding == null || embedding.conceptId() == null || embedding.conceptId().isBlank()) {
+				throw FHIRHelper.exception("Each embedding must include a concept id.", OperationOutcome.IssueType.INVALID, 400);
+			}
+			if (embedding.vector() == null || embedding.vector().length == 0) {
+				throw FHIRHelper.exception(
+						format("Embedding for concept '%s' must have at least one dimension.", embedding.conceptId()),
+						OperationOutcome.IssueType.INVALID,
+						400);
+			}
+			if (dimension == -1) {
+				dimension = embedding.vector().length;
+			} else if (dimension != embedding.vector().length) {
+				throw FHIRHelper.exception(
+						format("All embeddings in a batch must have the same vector size. Found %s and %s.", dimension, embedding.vector().length),
+						OperationOutcome.IssueType.INVALID,
+						400);
+			}
+			vectorsByConcept.put(embedding.conceptId(), embedding.vector());
+		}
+
+		BooleanQuery.Builder deleteQueryBuilder = new BooleanQuery.Builder()
+				.add(new TermQuery(new Term(QueryHelper.TYPE, DOC_TYPE)), BooleanClause.Occur.MUST)
+				.add(new TermQuery(new Term(MODEL_ID, resolvedModelId)), BooleanClause.Occur.MUST);
+
+		if (!replaceModel) {
+			deleteQueryBuilder.add(QueryHelper.termsQuery(CONCEPT_ID, vectorsByConcept.keySet()), BooleanClause.Occur.MUST);
+		}
+		indexIOProvider.deleteDocuments(deleteQueryBuilder.build());
+
+		String vectorFieldName = getVectorFieldName(resolvedModelId);
+		List<Document> docs = new ArrayList<>();
+		for (Map.Entry<String, float[]> entry : vectorsByConcept.entrySet()) {
+			Document embeddingDoc = new Document();
+			embeddingDoc.add(new StringField(QueryHelper.TYPE, DOC_TYPE, Field.Store.NO));
+			embeddingDoc.add(new StringField(MODEL_ID, resolvedModelId, Field.Store.NO));
+			embeddingDoc.add(new StringField(CONCEPT_ID, entry.getKey(), Field.Store.YES));
+			embeddingDoc.add(new KnnFloatVectorField(vectorFieldName, entry.getValue(), VectorSimilarityFunction.COSINE));
+			docs.add(embeddingDoc);
+		}
+
+		try {
+			indexIOProvider.writeDocuments(docs);
+		} catch (IllegalArgumentException e) {
+			throw FHIRHelper.exception(
+					format("Embedding dimension mismatch for model '%s'. If dimensions changed, reindex with replace=true.", resolvedModelId),
+					OperationOutcome.IssueType.INVALID,
+					400,
+					e);
+		}
+		return docs.size();
+	}
+
+	/*
+	 Binary payload format (little-endian):
+	 - 4 bytes magic: "SLE1"
+	 - int32 vector dimension
+	 - int32 record count
+	 - repeated records:
+	     - uint64 concept id
+	     - float32[dimension] embedding vector
+	 */
+	public List<EmbeddingInput> parseBinaryEmbeddings(InputStream inputStream) {
+		if (inputStream == null) {
+			throw FHIRHelper.exception("Binary embedding payload is required.", OperationOutcome.IssueType.REQUIRED, 400);
+		}
+
+		try (DataInputStream dataInputStream = new DataInputStream(new BufferedInputStream(inputStream))) {
+			byte[] magic = new byte[BINARY_MAGIC.length];
+			try {
+				dataInputStream.readFully(magic);
+			} catch (EOFException e) {
+				throw FHIRHelper.exception("Binary payload is too short. Expected header 'SLE1'.", OperationOutcome.IssueType.INVALID, 400, e);
+			}
+			if (!Arrays.equals(magic, BINARY_MAGIC)) {
+				throw FHIRHelper.exception("Binary payload must start with header 'SLE1'.", OperationOutcome.IssueType.INVALID, 400);
+			}
+
+			int dimension = readIntLittleEndian(dataInputStream, "dimension");
+			int count = readIntLittleEndian(dataInputStream, "count");
+			if (dimension <= 0) {
+				throw FHIRHelper.exception("Binary payload 'dimension' must be greater than zero.", OperationOutcome.IssueType.INVALID, 400);
+			}
+			if (dimension > MAX_VECTOR_DIMENSION) {
+				throw FHIRHelper.exception(
+						format("Binary payload 'dimension' exceeds the maximum of %s.", MAX_VECTOR_DIMENSION),
+						OperationOutcome.IssueType.INVALID,
+						400);
+			}
+			if (count <= 0) {
+				throw FHIRHelper.exception("Binary payload 'count' must be greater than zero.", OperationOutcome.IssueType.INVALID, 400);
+			}
+			if (count > MAX_BINARY_BATCH_SIZE) {
+				throw FHIRHelper.exception(
+						format("Binary payload 'count' exceeds the maximum of %s records.", MAX_BINARY_BATCH_SIZE),
+						OperationOutcome.IssueType.INVALID,
+						400);
+			}
+
+			List<EmbeddingInput> embeddings = new ArrayList<>(count);
+			for (int i = 0; i < count; i++) {
+				long conceptId = readLongLittleEndian(dataInputStream, format("concept id at record %s", i));
+				if (conceptId <= 0) {
+					throw FHIRHelper.exception(
+							format("Binary payload concept id at record %s must be greater than zero.", i),
+							OperationOutcome.IssueType.INVALID,
+							400);
+				}
+				float[] vector = new float[dimension];
+				for (int d = 0; d < dimension; d++) {
+					vector[d] = Float.intBitsToFloat(readIntLittleEndian(dataInputStream, format("vector value at record %s dimension %s", i, d)));
+				}
+				embeddings.add(new EmbeddingInput(Long.toString(conceptId), vector));
+			}
+
+			if (dataInputStream.read() != -1) {
+				throw FHIRHelper.exception("Binary payload contains trailing bytes after declared records.", OperationOutcome.IssueType.INVALID, 400);
+			}
+			return embeddings;
+		} catch (IOException e) {
+			throw FHIRHelper.exception("Unable to read binary embedding payload.", OperationOutcome.IssueType.INVALID, 400, e);
+		}
+	}
+
+	public SemanticSearchResult semanticSearch(String modelId, float[] queryVector, Set<String> conceptIdFilter, int count) throws IOException {
+		String resolvedModelId = resolveModelId(modelId);
+		if (queryVector == null || queryVector.length == 0) {
+			throw FHIRHelper.exception("A semantic query vector is required.", OperationOutcome.IssueType.REQUIRED, 400);
+		}
+		if (conceptIdFilter == null || conceptIdFilter.isEmpty() || count <= 0) {
+			return new SemanticSearchResult(0, List.of());
+		}
+
+		BooleanQuery filter = new BooleanQuery.Builder()
+				.add(new TermQuery(new Term(QueryHelper.TYPE, DOC_TYPE)), BooleanClause.Occur.MUST)
+				.add(new TermQuery(new Term(MODEL_ID, resolvedModelId)), BooleanClause.Occur.MUST)
+				.add(QueryHelper.termsQuery(CONCEPT_ID, conceptIdFilter), BooleanClause.Occur.MUST)
+				.build();
+
+		KnnFloatVectorQuery semanticQuery = new KnnFloatVectorQuery(getVectorFieldName(resolvedModelId), queryVector, count, filter);
+		TopDocs topDocs;
+		try {
+			topDocs = indexIOProvider.getIndexSearcher().search(semanticQuery, count);
+		} catch (IllegalArgumentException e) {
+			throw FHIRHelper.exception(
+					format("Query vector dimension mismatch for model '%s'.", resolvedModelId),
+					OperationOutcome.IssueType.INVALID,
+					400,
+					e);
+		}
+
+		StoredFields storedFields = indexIOProvider.getIndexSearcher().storedFields();
+		List<SemanticMatch> matches = new ArrayList<>();
+		for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+			String conceptId = storedFields.document(scoreDoc.doc).get(CONCEPT_ID);
+			if (conceptId != null) {
+				matches.add(new SemanticMatch(conceptId, scoreDoc.score));
+			}
+		}
+		return new SemanticSearchResult(topDocs.totalHits.value, matches);
+	}
+
+	public float[] parseVector(String vectorString, String parameterName) {
+		if (vectorString == null || vectorString.isBlank()) {
+			throw FHIRHelper.exception(
+					format("Parameter '%s' must contain a comma-separated float vector.", parameterName),
+					OperationOutcome.IssueType.REQUIRED,
+					400);
+		}
+
+		String normalized = vectorString.trim();
+		if (normalized.startsWith("[") && normalized.endsWith("]")) {
+			normalized = normalized.substring(1, normalized.length() - 1);
+		}
+		normalized = normalized.trim();
+		if (normalized.isEmpty()) {
+			throw FHIRHelper.exception(
+					format("Parameter '%s' must contain at least one float value.", parameterName),
+					OperationOutcome.IssueType.INVALID,
+					400);
+		}
+
+		String[] tokens = normalized.contains(",") ? normalized.split("\\s*,\\s*") : normalized.split("\\s+");
+		float[] vector = new float[tokens.length];
+		for (int i = 0; i < tokens.length; i++) {
+			String token = tokens[i].trim();
+			if (token.isEmpty()) {
+				throw FHIRHelper.exception(
+						format("Parameter '%s' contains an empty vector entry.", parameterName),
+						OperationOutcome.IssueType.INVALID,
+						400);
+			}
+			try {
+				vector[i] = Float.parseFloat(token);
+			} catch (NumberFormatException e) {
+				throw FHIRHelper.exception(
+						format("Parameter '%s' contains non-numeric value '%s'.", parameterName, token),
+						OperationOutcome.IssueType.INVALID,
+						400,
+						e);
+			}
+		}
+		return vector;
+	}
+
+	public String resolveModelId(String modelId) {
+		String resolvedModelId = modelId == null || modelId.isBlank() ? DEFAULT_MODEL_ID : modelId.trim();
+		if (resolvedModelId.length() > 100) {
+			throw FHIRHelper.exception("Model id must be 100 characters or less.", OperationOutcome.IssueType.INVALID, 400);
+		}
+		return resolvedModelId;
+	}
+
+	private String getVectorFieldName(String modelId) {
+		String cleaned = modelId.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", "_");
+		if (cleaned.isBlank()) {
+			cleaned = DEFAULT_MODEL_ID;
+		}
+		return VECTOR_FIELD_PREFIX + cleaned + "_" + Integer.toHexString(modelId.hashCode());
+	}
+
+	private int readIntLittleEndian(DataInputStream dataInputStream, String fieldName) throws IOException {
+		try {
+			return Integer.reverseBytes(dataInputStream.readInt());
+		} catch (EOFException e) {
+			throw FHIRHelper.exception(
+					format("Binary payload ended while reading %s.", fieldName),
+					OperationOutcome.IssueType.INVALID,
+					400,
+					e);
+		}
+	}
+
+	private long readLongLittleEndian(DataInputStream dataInputStream, String fieldName) throws IOException {
+		try {
+			return Long.reverseBytes(dataInputStream.readLong());
+		} catch (EOFException e) {
+			throw FHIRHelper.exception(
+					format("Binary payload ended while reading %s.", fieldName),
+					OperationOutcome.IssueType.INVALID,
+					400,
+					e);
+		}
+	}
+}

--- a/src/main/java/org/snomed/snowstormlite/service/SemanticQueryRequest.java
+++ b/src/main/java/org/snomed/snowstormlite/service/SemanticQueryRequest.java
@@ -1,0 +1,34 @@
+package org.snomed.snowstormlite.service;
+
+public class SemanticQueryRequest {
+
+	private final boolean enabled;
+	private final String modelId;
+	private final float[] vector;
+
+	private SemanticQueryRequest(boolean enabled, String modelId, float[] vector) {
+		this.enabled = enabled;
+		this.modelId = modelId;
+		this.vector = vector;
+	}
+
+	public static SemanticQueryRequest disabled() {
+		return new SemanticQueryRequest(false, null, null);
+	}
+
+	public static SemanticQueryRequest enabled(String modelId, float[] vector) {
+		return new SemanticQueryRequest(true, modelId, vector);
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public String getModelId() {
+		return modelId;
+	}
+
+	public float[] getVector() {
+		return vector;
+	}
+}

--- a/src/main/java/org/snomed/snowstormlite/service/ValueSetService.java
+++ b/src/main/java/org/snomed/snowstormlite/service/ValueSetService.java
@@ -6,6 +6,7 @@ import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
@@ -43,6 +44,7 @@ public class ValueSetService {
 
 	// Constant to help with "?fhir_vs=refset"
 	public static final String REFSETS_WITH_MEMBERS = "Refsets";
+	public static final String SEMANTIC_SCORE_EXTENSION_URL = "http://snomed.info/fhir/StructureDefinition/valueset-expansion-semantic-score";
 
 	@Autowired
 	private CodeSystemRepository codeSystemRepository;
@@ -55,6 +57,9 @@ public class ValueSetService {
 
 	@Autowired
 	private ValueSetRepository valueSetRepository;
+
+	@Autowired(required = false)
+	private EmbeddingIndexService embeddingIndexService;
 
 	@Autowired
 	private LanguageCharacterFoldingConfiguration languageCharacterFoldingConfiguration;
@@ -224,18 +229,32 @@ public class ValueSetService {
 	public ValueSet expand(String url, String termFilter, List<LanguageDialect> displayLanguages,
 						   boolean includeDesignations, int offset, int count) throws IOException {
 
+		return expand(url, termFilter, displayLanguages, includeDesignations, offset, count, SemanticQueryRequest.disabled());
+	}
+
+	public ValueSet expand(String url, String termFilter, List<LanguageDialect> displayLanguages,
+						   boolean includeDesignations, int offset, int count, SemanticQueryRequest semanticQuery) throws IOException {
+
 		ValueSet valueSet = createSnomedImplicitValueSet(url);
-		return expand(new FHIRValueSet(valueSet), termFilter, displayLanguages, includeDesignations, Collections.emptyList(), offset, count, null).getFirst();
+		return expand(new FHIRValueSet(valueSet), termFilter, displayLanguages, includeDesignations, Collections.emptyList(), offset, count, null, semanticQuery).getFirst();
 	}
 
 	public Pair<ValueSet, List<FHIRConcept>> expand(FHIRValueSet internalValueSet, String termFilter, List<LanguageDialect> displayLanguages,
 						   boolean includeDesignations, List<String> requestedProperties, int offset, int count, Set<Coding> codingsToValidate) throws IOException {
 
+		return expand(internalValueSet, termFilter, displayLanguages, includeDesignations, requestedProperties, offset, count, codingsToValidate, SemanticQueryRequest.disabled());
+	}
+
+	public Pair<ValueSet, List<FHIRConcept>> expand(FHIRValueSet internalValueSet, String termFilter, List<LanguageDialect> displayLanguages,
+													boolean includeDesignations, List<String> requestedProperties, int offset, int count,
+													Set<Coding> codingsToValidate, SemanticQueryRequest semanticQuery) throws IOException {
+
+		boolean semanticSearchEnabled = semanticQuery != null && semanticQuery.isEnabled();
 		int originalCount = count;
 		int originalOffset = offset;
 
 		// Apply additional sorting for the first 100 results
-		boolean additionalSorting = offset < 100;
+		boolean additionalSorting = !semanticSearchEnabled && offset < 100;
 		if (additionalSorting) {
 			offset = 0;
 			count = originalOffset + originalCount;
@@ -253,30 +272,62 @@ public class ValueSetService {
 		}
 
 		Function<FHIRDescription, Boolean> termMatcher = null;
-		if (termFilter != null && !termFilter.isBlank()) {
+		if (!semanticSearchEnabled && termFilter != null && !termFilter.isBlank()) {
 			termMatcher = addTermQuery(termFilter, displayLanguages, valueSetExpandQuery);
 		}
 		Query query = valueSetExpandQuery.build();
-		Sort sort = new Sort(
-				new SortedNumericSortField(FHIRConcept.FieldNames.ACTIVE_SORT, SortField.Type.INT, true),
-				new SortedNumericSortField(FHIRConcept.FieldNames.PT_AND_FSN_TERM_LENGTH, SortField.Type.INT),
-				SortField.FIELD_SCORE);
-		TopDocs queryResult = indexSearcher.search(query, offset + count, sort, true);
 
 		List<ValueSet.ValueSetExpansionContainsComponent> contains = new ArrayList<>();
-		int offsetReached = 0;
-
 		List<FHIRConcept> conceptPage = new ArrayList<>();
-		StoredFields storedFields = indexSearcher.storedFields();
-		for (ScoreDoc scoreDoc : queryResult.scoreDocs) {
-			if (offsetReached < offset) {
-				offsetReached++;
-				continue;
+		Map<String, Float> semanticScoresByCode = new HashMap<>();
+		long totalHits;
+
+		if (semanticSearchEnabled) {
+			Set<String> candidateConceptIds = fetchConceptIds(indexSearcher, query);
+			int requestedResultCount = Math.max(offset + count, 1);
+			EmbeddingIndexService.SemanticSearchResult semanticSearchResult = embeddingIndexService.semanticSearch(
+					semanticQuery.getModelId(),
+					semanticQuery.getVector(),
+					candidateConceptIds,
+					requestedResultCount);
+			totalHits = semanticSearchResult.totalHits();
+
+			int offsetReached = 0;
+			for (EmbeddingIndexService.SemanticMatch semanticMatch : semanticSearchResult.matches()) {
+				if (offsetReached < offset) {
+					offsetReached++;
+					continue;
+				}
+				FHIRConcept concept = codeSystemRepository.getConcept(semanticMatch.conceptId());
+				if (concept == null) {
+					continue;
+				}
+				conceptPage.add(concept);
+				semanticScoresByCode.put(concept.getConceptId(), semanticMatch.score());
+				if (conceptPage.size() == count) {
+					break;
+				}
 			}
-			FHIRConcept concept = codeSystemRepository.getConceptFromDoc(storedFields.document(scoreDoc.doc));
-			conceptPage.add(concept);
-			if (conceptPage.size() == count) {
-				break;
+		} else {
+			Sort sort = new Sort(
+					new SortedNumericSortField(FHIRConcept.FieldNames.ACTIVE_SORT, SortField.Type.INT, true),
+					new SortedNumericSortField(FHIRConcept.FieldNames.PT_AND_FSN_TERM_LENGTH, SortField.Type.INT),
+					SortField.FIELD_SCORE);
+			TopDocs queryResult = indexSearcher.search(query, offset + count, sort, true);
+			totalHits = queryResult.totalHits.value;
+
+			int offsetReached = 0;
+			StoredFields storedFields = indexSearcher.storedFields();
+			for (ScoreDoc scoreDoc : queryResult.scoreDocs) {
+				if (offsetReached < offset) {
+					offsetReached++;
+					continue;
+				}
+				FHIRConcept concept = codeSystemRepository.getConceptFromDoc(storedFields.document(scoreDoc.doc));
+				conceptPage.add(concept);
+				if (conceptPage.size() == count) {
+					break;
+				}
 			}
 		}
 
@@ -345,6 +396,10 @@ public class ValueSetService {
 				extension.addExtension("code", new CodeType("sufficientlyDefined"));
 				extension.addExtension("value", new BooleanType(concept.isDefined()));
 			}
+			Float semanticScore = semanticScoresByCode.get(concept.getConceptId());
+			if (semanticScore != null) {
+				component.addExtension(SEMANTIC_SCORE_EXTENSION_URL, new DecimalType(semanticScore));
+			}
 			contains.add(component);
 		}
 
@@ -354,12 +409,40 @@ public class ValueSetService {
 		ValueSet.ValueSetExpansionComponent expansion = new ValueSet.ValueSetExpansionComponent();
 		expansion.setIdentifier(UUID.randomUUID().toString());
 		expansion.setTimestamp(new Date());
-		expansion.setTotal((int) queryResult.totalHits.value);
+		expansion.setTotal((int) totalHits);
 		FHIRCodeSystem codeSystem = codeSystemRepository.getCodeSystem();
 		expansion.addParameter(new ValueSet.ValueSetExpansionParameterComponent(new StringType("version")).setValue(new UriType(codeSystem.getSystemAndVersionUri())));
 		expansion.setContains(contains);
 		valueSet.setExpansion(expansion);
 		return Pair.of(valueSet, conceptPage);
+	}
+
+	private Set<String> fetchConceptIds(IndexSearcher indexSearcher, Query query) throws IOException {
+		Set<String> conceptIds = new HashSet<>();
+		StoredFields storedFields = indexSearcher.storedFields();
+		indexSearcher.search(query, new SimpleCollector() {
+			private int docBase;
+
+			@Override
+			protected void doSetNextReader(LeafReaderContext context) throws IOException {
+				docBase = context.docBase;
+				super.doSetNextReader(context);
+			}
+
+			@Override
+			public ScoreMode scoreMode() {
+				return ScoreMode.COMPLETE_NO_SCORES;
+			}
+
+			@Override
+			public void collect(int doc) throws IOException {
+				String conceptId = storedFields.document(docBase + doc).get(FHIRConcept.FieldNames.ID);
+				if (conceptId != null) {
+					conceptIds.add(conceptId);
+				}
+			}
+		});
+		return conceptIds;
 	}
 
 	private BooleanQuery.@NotNull Builder getValueSetExpandQuery(FHIRValueSet valueSet) throws IOException {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,9 @@ syndication.password=
 # Lucene index directory
 index.path=lucene-index
 
+# Embedding-powered semantic search (optional, disabled by default)
+snowstorm.embeddings.enabled=false
+
 # Import batch size in thousands
 # Limited to 40 thousand by default, to allow import to complete within a 1GB memory limit
 import.batch-size=40
@@ -118,17 +121,17 @@ search.dialect.en-default=900000000000509007
 #   All characters will be converted to lowercase for this part of the index.
 #   Tool for UTF-16 conversion here https://www.branah.com/unicode-converter
 # ----------------------------------------
-# Danish жше
+# Danish пїЅпїЅпїЅ
 search.language.charactersNotFolded.da=\u00e6\u00f8\u00e5
-# Finnish едц
+# Finnish пїЅпїЅпїЅ
 search.language.charactersNotFolded.fi=\u00e5\u00e4\u00f6
 # French - No diacritic characters
 search.language.charactersNotFolded.fr=
-# Norwegian жше
+# Norwegian пїЅпїЅпїЅ
 search.language.charactersNotFolded.no=\u00e6\u00f8\u00e5
 # Spanish - all characters folded to allow simple form to match
 search.language.charactersNotFolded.es=
-# Swedish едц
+# Swedish пїЅпїЅпїЅ
 search.language.charactersNotFolded.sv=\u00e5\u00e4\u00f6
 
 

--- a/src/test/java/org/snomed/snowstormlite/AdminFeaturesDisabledTest.java
+++ b/src/test/java/org/snomed/snowstormlite/AdminFeaturesDisabledTest.java
@@ -1,0 +1,54 @@
+package org.snomed.snowstormlite;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = TestConfig.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = "snowstorm.embeddings.enabled=false")
+class AdminFeaturesDisabledTest {
+
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+	@Test
+	void featuresEndpointReportsEmbeddingsDisabled() {
+		ResponseEntity<Map> response = restTemplate.exchange(
+				"/fhir-admin/features",
+				HttpMethod.GET,
+				null,
+				Map.class
+		);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		Map<String, Object> body = response.getBody();
+		assertNotNull(body);
+		assertEquals("snowstorm-lite", body.get("product"));
+		assertEquals(Boolean.FALSE, body.get("embeddingsSupported"));
+		assertEquals(Boolean.FALSE, body.get("semanticSearchSupported"));
+
+		Map<String, Object> features = (Map<String, Object>) body.get("features");
+		assertNotNull(features);
+		assertEquals(Boolean.FALSE, features.get("semanticExpand"));
+		assertEquals(Boolean.FALSE, features.get("semanticMatchOperation"));
+		assertEquals(Boolean.FALSE, features.get("embeddingIndexOperation"));
+		assertEquals(Boolean.FALSE, features.get("embeddingBinaryIndexOperation"));
+		assertEquals(Boolean.FALSE, features.get("semanticSearchWithinEcl"));
+
+		assertNull(body.get("operations"), "Operations should not be advertised when embeddings are disabled");
+	}
+}

--- a/src/test/java/org/snomed/snowstormlite/AdminFeaturesEndpointTest.java
+++ b/src/test/java/org/snomed/snowstormlite/AdminFeaturesEndpointTest.java
@@ -1,0 +1,51 @@
+package org.snomed.snowstormlite;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = TestConfig.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AdminFeaturesEndpointTest {
+
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+	@Test
+	void featuresEndpointAdvertisesEmbeddingCapabilities() {
+		ResponseEntity<Map> response = restTemplate.exchange(
+				"/fhir-admin/features",
+				HttpMethod.GET,
+				null,
+				Map.class
+		);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		Map<String, Object> body = response.getBody();
+		assertNotNull(body);
+		assertEquals(1, body.get("schemaVersion"));
+		assertEquals("snowstorm-lite", body.get("product"));
+		assertEquals(Boolean.TRUE, body.get("embeddingsSupported"));
+		assertEquals(Boolean.TRUE, body.get("semanticSearchSupported"));
+
+		Map<String, Object> features = (Map<String, Object>) body.get("features");
+		assertNotNull(features);
+		assertEquals(Boolean.TRUE, features.get("semanticExpand"));
+		assertEquals(Boolean.TRUE, features.get("semanticMatchOperation"));
+		assertEquals(Boolean.TRUE, features.get("embeddingIndexOperation"));
+		assertEquals(Boolean.TRUE, features.get("embeddingBinaryIndexOperation"));
+		assertEquals(Boolean.TRUE, features.get("semanticSearchWithinEcl"));
+	}
+}

--- a/src/test/java/org/snomed/snowstormlite/service/EmbeddingIndexServiceBinaryFormatTest.java
+++ b/src/test/java/org/snomed/snowstormlite/service/EmbeddingIndexServiceBinaryFormatTest.java
@@ -1,0 +1,63 @@
+package org.snomed.snowstormlite.service;
+
+import org.junit.jupiter.api.Test;
+import org.snomed.snowstormlite.fhir.FHIRServerResponseException;
+
+import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EmbeddingIndexServiceBinaryFormatTest {
+
+	@Test
+	void parseBinaryEmbeddingsParsesValidPayload() {
+		EmbeddingIndexService service = new EmbeddingIndexService();
+		byte[] payload = buildPayload(3, new long[]{100001L, 100002L}, new float[][]{
+				{0.1f, 0.2f, 0.3f},
+				{1.1f, 1.2f, 1.3f}
+		});
+
+		List<EmbeddingIndexService.EmbeddingInput> embeddings = service.parseBinaryEmbeddings(new ByteArrayInputStream(payload));
+
+		assertEquals(2, embeddings.size());
+		assertEquals("100001", embeddings.get(0).conceptId());
+		assertArrayEquals(new float[]{0.1f, 0.2f, 0.3f}, embeddings.get(0).vector(), 0.000001f);
+		assertEquals("100002", embeddings.get(1).conceptId());
+		assertArrayEquals(new float[]{1.1f, 1.2f, 1.3f}, embeddings.get(1).vector(), 0.000001f);
+	}
+
+	@Test
+	void parseBinaryEmbeddingsRejectsInvalidHeader() {
+		EmbeddingIndexService service = new EmbeddingIndexService();
+		byte[] payload = buildPayload(2, new long[]{100001L}, new float[][]{{0.5f, 0.6f}});
+		payload[0] = 'X';
+
+		assertThrows(FHIRServerResponseException.class, () -> service.parseBinaryEmbeddings(new ByteArrayInputStream(payload)));
+	}
+
+	private byte[] buildPayload(int dimension, long[] conceptIds, float[][] vectors) {
+		int count = conceptIds.length;
+		ByteBuffer buffer = ByteBuffer
+				.allocate(4 + Integer.BYTES + Integer.BYTES + count * (Long.BYTES + (dimension * Float.BYTES)))
+				.order(ByteOrder.LITTLE_ENDIAN);
+
+		buffer.put((byte) 'S');
+		buffer.put((byte) 'L');
+		buffer.put((byte) 'E');
+		buffer.put((byte) '1');
+		buffer.putInt(dimension);
+		buffer.putInt(count);
+		for (int i = 0; i < count; i++) {
+			buffer.putLong(conceptIds[i]);
+			for (int d = 0; d < dimension; d++) {
+				buffer.putFloat(vectors[i][d]);
+			}
+		}
+		return buffer.array();
+	}
+}

--- a/src/test/java/org/snomed/snowstormlite/service/SemanticSearchTest.java
+++ b/src/test/java/org/snomed/snowstormlite/service/SemanticSearchTest.java
@@ -1,0 +1,128 @@
+package org.snomed.snowstormlite.service;
+
+import org.hl7.fhir.r4.model.ValueSet;
+import org.ihtsdo.otf.snomedboot.ReleaseImportException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.snomed.snowstormlite.TestConfig;
+import org.snomed.snowstormlite.TestService;
+import org.snomed.snowstormlite.fhir.CodeSystemProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.snomed.snowstormlite.TestService.EN_LANGUAGE_DIALECTS;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = TestConfig.class)
+class SemanticSearchTest {
+
+	@Autowired
+	private TestService testService;
+
+	@Autowired
+	private ValueSetService valueSetService;
+
+	@Autowired
+	private EmbeddingIndexService embeddingIndexService;
+
+	@Autowired
+	private CodeSystemProvider codeSystemProvider;
+
+	@Test
+	void semanticExpandRespectsEclFilterAndRanking() throws IOException, ReleaseImportException {
+		testService.importRF2Int();
+
+		embeddingIndexService.indexEmbeddings(EmbeddingIndexService.DEFAULT_MODEL_ID, List.of(
+				new EmbeddingIndexService.EmbeddingInput("404684003", new float[]{1f, 0f}),
+				new EmbeddingIndexService.EmbeddingInput("362969004", new float[]{0.8f, 0.2f}),
+				new EmbeddingIndexService.EmbeddingInput("313005", new float[]{0f, 1f}),
+				new EmbeddingIndexService.EmbeddingInput("138875005", new float[]{0.99f, 0.01f})
+		), true);
+
+		ValueSet semanticExpand = valueSetService.expand(
+				"http://snomed.info/sct?fhir_vs=ecl/<< 404684003 |Clinical finding|",
+				null,
+				EN_LANGUAGE_DIALECTS,
+				false,
+				0,
+				10,
+				SemanticQueryRequest.enabled(EmbeddingIndexService.DEFAULT_MODEL_ID, new float[]{1f, 0f}));
+
+		List<String> returnedCodes = semanticExpand.getExpansion().getContains().stream()
+				.map(ValueSet.ValueSetExpansionContainsComponent::getCode)
+				.toList();
+		assertEquals(List.of("404684003", "362969004", "313005"), returnedCodes);
+		assertTrue(returnedCodes.stream().noneMatch("138875005"::equals));
+
+		for (ValueSet.ValueSetExpansionContainsComponent containsComponent : semanticExpand.getExpansion().getContains()) {
+			assertNotNull(containsComponent.getExtensionByUrl(ValueSetService.SEMANTIC_SCORE_EXTENSION_URL));
+		}
+	}
+
+	@Test
+	void binaryIndexOperationSupportsSemanticSearch() throws IOException, ReleaseImportException {
+		testService.importRF2Int();
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setContentType("application/octet-stream");
+		request.setParameter("model", "binary-test-model");
+		request.setParameter("replace", "true");
+		request.setContent(buildBinaryPayload(2, new long[]{404684003L, 362969004L, 313005L}, new float[][]{
+				{1f, 0f},
+				{0.8f, 0.2f},
+				{0f, 1f}
+		}));
+
+		codeSystemProvider.indexEmbeddingsBinary(request, null, null);
+
+		ValueSet semanticExpand = valueSetService.expand(
+				"http://snomed.info/sct?fhir_vs=ecl/<< 404684003 |Clinical finding|",
+				null,
+				EN_LANGUAGE_DIALECTS,
+				false,
+				0,
+				10,
+				SemanticQueryRequest.enabled("binary-test-model", new float[]{1f, 0f}));
+
+		List<String> returnedCodes = semanticExpand.getExpansion().getContains().stream()
+				.map(ValueSet.ValueSetExpansionContainsComponent::getCode)
+				.toList();
+		assertEquals(List.of("404684003", "362969004", "313005"), returnedCodes);
+	}
+
+	@AfterEach
+	public void after() throws IOException {
+		testService.tearDown();
+	}
+
+	private byte[] buildBinaryPayload(int dimension, long[] conceptIds, float[][] vectors) {
+		ByteBuffer buffer = ByteBuffer
+				.allocate(4 + Integer.BYTES + Integer.BYTES + conceptIds.length * (Long.BYTES + (dimension * Float.BYTES)))
+				.order(ByteOrder.LITTLE_ENDIAN);
+
+		buffer.put((byte) 'S');
+		buffer.put((byte) 'L');
+		buffer.put((byte) 'E');
+		buffer.put((byte) '1');
+		buffer.putInt(dimension);
+		buffer.putInt(conceptIds.length);
+		for (int i = 0; i < conceptIds.length; i++) {
+			buffer.putLong(conceptIds[i]);
+			for (int d = 0; d < dimension; d++) {
+				buffer.putFloat(vectors[i][d]);
+			}
+		}
+		return buffer.array();
+	}
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,5 +1,8 @@
 index.path=test-lucene-index
 
+# Enable embedding support for tests
+snowstorm.embeddings.enabled=true
+
 logging.level.org.springframework=INFO
 
 # Root logging level (everything else).


### PR DESCRIPTION
Introduce BYOE (bring your own embeddings) semantic search as an opt-in feature gated by `snowstorm.embeddings.enabled` (default: false).

When enabled, adds:
- $index-embeddings and $index-embeddings-binary operations for ingesting pre-computed concept embeddings into the shared Lucene index
- $semantic-match operation for direct semantic queries
- _semantic parameter on ValueSet/$expand for semantic search within ECL
- /fhir-admin/features endpoint for capability discovery
- Semantic score extension on expansion results

When disabled (default), the EmbeddingIndexService bean is not created, all embedding operations return 501 with a clear message, and the features endpoint reports all embedding capabilities as false. Existing FHIR operations are completely unaffected.