### PR TITLE
Dashboard enhancements: syndication fixes, settings, and SNOMED mini-browser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<description>SNOMED-CT FHIR Terminology Server, with a small memory footprint</description>
 
 	<artifactId>snowstorm-lite</artifactId>
-	<version>2.4.0</version>
+	<version>2.4.1-SNAPSHOT</version>
 	<parent>
 		<groupId>org.snomed</groupId>
 		<artifactId>snomed-parent-bom</artifactId>

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ A fast FHIR Terminology Server for SNOMED CT with a small memory footprint.
 - FHIR Terminology Operations
   - CodeSystem lookup
     - Including parents, children, designations, normal form
+  - CodeSystem \$validate-code
   - ValueSet create/edit/delete, \$expand and \$validate-code
   - ConceptMap create/edit/delete and \$translate
   - [SNOMED CT Implicit Value Sets](http://hl7.org/fhir/R4/snomedct.html#implicit)

--- a/src/main/java/org/snomed/snowstormlite/config/BasicAuthWebSecurityConfiguration.java
+++ b/src/main/java/org/snomed/snowstormlite/config/BasicAuthWebSecurityConfiguration.java
@@ -36,6 +36,8 @@ public class BasicAuthWebSecurityConfiguration {
 						.requestMatchers(HttpMethod.POST, "/fhir/ValueSet/*/$expand").permitAll()
 						.requestMatchers(HttpMethod.POST, "/fhir/ValueSet/$validate-code").permitAll()
 						.requestMatchers(HttpMethod.POST, "/fhir/ValueSet/*/$validate-code").permitAll()
+						.requestMatchers(HttpMethod.POST, "/fhir/CodeSystem/$validate-code").permitAll()
+						.requestMatchers(HttpMethod.POST, "/fhir/CodeSystem/*/$validate-code").permitAll()
 						.requestMatchers(HttpMethod.POST, "/fhir/ValueSet").authenticated()
 						.requestMatchers(HttpMethod.POST, "/fhir/ValueSet/*").authenticated()
 						.requestMatchers(HttpMethod.PUT, "/fhir/ValueSet/*").authenticated()

--- a/src/main/java/org/snomed/snowstormlite/fhir/CodeSystemProvider.java
+++ b/src/main/java/org/snomed/snowstormlite/fhir/CodeSystemProvider.java
@@ -15,10 +15,13 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static java.lang.String.format;
 import static org.snomed.snowstormlite.fhir.FHIRConstants.ACCEPT_LANGUAGE_HEADER;
+import static org.snomed.snowstormlite.fhir.FHIRConstants.SNOMED_URI;
 import static org.snomed.snowstormlite.fhir.FHIRHelper.*;
 
 @Component
@@ -113,6 +116,67 @@ public class CodeSystemProvider implements IResourceProvider {
 		String codeBValue = recoverCode(codeB, codingB);
 		
 		return codeSystemService.subsumes(codeSystem, codeAValue, codeBValue);
+	}
+
+	@Operation(name="$validate-code", idempotent=true)
+	public Parameters validateCode(
+			HttpServletRequest request,
+			@IdParam(optional = true) IdType id,
+			@OperationParam(name="url") UriType url,
+			@OperationParam(name="code") String code,
+			@OperationParam(name="system") UriType system,
+			@OperationParam(name="version") String systemVersion,
+			@OperationParam(name="coding") Coding coding,
+			@OperationParam(name="codeableConcept") CodeableConcept codeableConcept,
+			@OperationParam(name="display") String display,
+			@OperationParam(name="date") String date,
+			@OperationParam(name="abstract") BooleanType abstractBool,
+			@OperationParam(name="displayLanguage") String displayLanguage,
+			@OperationParam(name="system-version") String incorrectParamSystemVersion) throws IOException {
+
+		notSupported("date", date);
+		parameterNamingHint("system-version", incorrectParamSystemVersion, "version");
+
+		requireExactlyOneOf("code", code, "coding", coding, "codeableConcept", codeableConcept);
+		if (code != null && system == null && url == null && id == null) {
+			throw exception("One of 'system', 'url', or the CodeSystem id must be supplied when using 'code'.",
+					OperationOutcome.IssueType.INVARIANT, 400);
+		}
+		mutuallyRequired("display", display, "code", code, "coding", coding);
+
+		Set<Coding> codingsToValidate = new HashSet<>();
+		if (code != null) {
+			String systemFromUrl = url != null ? FHIRHelper.toString(url) : SNOMED_URI;
+			String codeSystemUrl = system != null ? FHIRHelper.toString(system) : systemFromUrl;
+			codingsToValidate.add(new Coding(codeSystemUrl, code, display).setVersion(systemVersion));
+		} else if (coding != null) {
+			coding.setDisplay(display);
+			codingsToValidate.add(coding);
+		} else {
+			codingsToValidate.addAll(codeableConcept.getCoding());
+		}
+		if (codingsToValidate.isEmpty()) {
+			throw exception("No codings provided to validate.", OperationOutcome.IssueType.INVALID, 400);
+		}
+
+		FHIRCodeSystem loadedCodeSystem = codeSystemRepository.getCodeSystem();
+		if (loadedCodeSystem == null) {
+			throw exception("No CodeSystem is loaded on this server.", OperationOutcome.IssueType.NOTFOUND, 404);
+		}
+
+		Coding firstCoding = codingsToValidate.size() == 1 ? codingsToValidate.iterator().next() : null;
+		Coding codingForParams = coding != null ? coding : firstCoding;
+		CodeSystemVersionParams codeSystemVersionParams = getCodeSystemVersionParams(id, url != null ? url : system,
+				systemVersion != null ? new StringType(systemVersion) : null, codingForParams);
+		if (!codeSystemVersionParams.matchesCodeSystem(loadedCodeSystem)) {
+			Parameters response = new Parameters();
+			response.addParameter("result", false);
+			response.addParameter("message", format("Code system not found for parameters %s.", codeSystemVersionParams));
+			return response;
+		}
+
+		List<LanguageDialect> languageDialects = languageDialectParser.parseAcceptLanguageHeader(displayLanguage);
+		return codeSystemService.validateCode(loadedCodeSystem, codingsToValidate, languageDialects, displayLanguage);
 	}
 
 	private FHIRCodeSystem getCodeSystemVersionOrThrow(UriType system, StringType version, Coding coding) {

--- a/src/main/java/org/snomed/snowstormlite/fhir/CodeSystemProvider.java
+++ b/src/main/java/org/snomed/snowstormlite/fhir/CodeSystemProvider.java
@@ -91,30 +91,6 @@ public class CodeSystemProvider implements IResourceProvider {
 		return codeSystemService.lookup(codeSystem, recoverCode(code, coding), languageDialects);
 	}
 
-	@Operation(name="$validate-code", idempotent=true)
-	public Parameters validateCode(
-			HttpServletRequest request,
-			HttpServletResponse response,
-			@OperationParam(name="url") UriType url,
-			@OperationParam(name="code") CodeType code,
-			@OperationParam(name="system") UriType system,
-			@OperationParam(name="version") StringType version,
-			@OperationParam(name="display") StringType display,
-			@OperationParam(name="coding") Coding coding,
-			@OperationParam(name="date") StringType date,
-			@OperationParam(name="displayLanguage") String displayLanguage) {
-
-		mutuallyExclusive("code", code, "coding", coding);
-		notSupported("date", date);
-		// CodeSystem/$validate-code identifies the system via 'url'; accept 'system' too for symmetry with $lookup
-		UriType effectiveSystem = system != null ? system : url;
-		FHIRCodeSystem codeSystem = getCodeSystemVersionOrThrow(effectiveSystem, version, coding);
-		String codeValue = recoverCode(code, coding);
-		String displayValue = display != null ? display.getValue() : (coding != null ? coding.getDisplay() : null);
-		List<LanguageDialect> languageDialects = languageDialectParser.parseDisplayLanguageWithDefaultFallback(displayLanguage, request.getHeader(ACCEPT_LANGUAGE_HEADER));
-		return codeSystemService.validateCode(codeSystem, codeValue, displayValue, languageDialects);
-	}
-
 	@Operation(name="$subsumes", idempotent=true)
 	public Parameters subsumes(
 			HttpServletRequest request,

--- a/src/main/java/org/snomed/snowstormlite/service/CodeSystemService.java
+++ b/src/main/java/org/snomed/snowstormlite/service/CodeSystemService.java
@@ -3,6 +3,7 @@ package org.snomed.snowstormlite.service;
 import org.hl7.fhir.r4.model.*;
 import org.snomed.snowstormlite.domain.FHIRCodeSystem;
 import org.snomed.snowstormlite.domain.FHIRConcept;
+import org.snomed.snowstormlite.domain.FHIRDescription;
 import org.snomed.snowstormlite.domain.LanguageDialect;
 import org.snomed.snowstormlite.domain.graph.GraphNode;
 import org.snomed.snowstormlite.fhir.FHIRConstants;
@@ -13,7 +14,10 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 
+import static java.lang.String.format;
+import static org.snomed.snowstormlite.fhir.FHIRConstants.SNOMED_URI;
 import static org.snomed.snowstormlite.fhir.FHIRHelper.exception;
 
 @Service
@@ -64,6 +68,103 @@ public class CodeSystemService {
 		} while (!remainingCodes.isEmpty());
 
 		return allGraphNodes;
+	}
+
+	public Parameters validateCode(FHIRCodeSystem codeSystem, Set<Coding> codingsToValidate, List<LanguageDialect> languageDialects,
+			String displayLanguage) throws IOException {
+		Parameters response = new Parameters();
+
+		if (codingsToValidate.size() == 1) {
+			Coding coding = codingsToValidate.iterator().next();
+			response.addParameter("code", coding.getCode());
+			response.addParameter("system", coding.getSystem());
+		}
+
+		Set<Coding> codingsInCodeSystem = codingsToValidate.stream()
+				.filter(coding -> SNOMED_URI.equals(coding.getSystem()) && versionsMatch(coding, codeSystem))
+				.collect(Collectors.toCollection(LinkedHashSet::new));
+
+		if (codingsInCodeSystem.isEmpty()) {
+			response.addParameter("result", false);
+			if (codingsToValidate.stream().anyMatch(coding -> SNOMED_URI.equals(coding.getSystem()))) {
+				if (codingsToValidate.size() == 1) {
+					Coding coding = codingsToValidate.iterator().next();
+					response.addParameter("message", format("The system '%s' is known but the version '%s' is not.",
+							coding.getSystem(), coding.getVersion()));
+				} else {
+					response.addParameter("message", "One or more codings use a known system but none of the versions match.");
+				}
+			} else if (codingsToValidate.size() == 1) {
+				Coding coding = codingsToValidate.iterator().next();
+				response.addParameter("message", format("The system '%s' is not known.", coding.getSystem()));
+			} else {
+				response.addParameter("message", "None of the codings use a known code system.");
+			}
+			return response;
+		}
+
+		if (codingsToValidate.size() == 1) {
+			response.addParameter("version", codeSystem.getVersionUri());
+		}
+
+		for (Coding coding : codingsInCodeSystem) {
+			FHIRConcept concept = repository.getConcept(coding.getCode());
+			if (concept == null) {
+				continue;
+			}
+
+			if (codingsToValidate.size() == 1) {
+				response.addParameter("display", concept.getPT(languageDialects));
+				response.addParameter("inactive", !concept.isActive());
+			}
+
+			String codingDisplay = coding.getDisplay();
+			if (codingDisplay == null) {
+				response.addParameter("result", true);
+				return response;
+			}
+
+			FHIRDescription termMatch = null;
+			for (FHIRDescription designation : concept.getDescriptions()) {
+				if (codingDisplay.equalsIgnoreCase(designation.getTerm())) {
+					termMatch = designation;
+					if (designation.getLang() == null || languageDialects.isEmpty() || languageDialects.stream()
+							.anyMatch(languageDialect -> designation.getLang().equals(languageDialect.getLanguageCode()))) {
+						response.addParameter("result", true);
+						response.addParameter("message", format("The code '%s' is valid and the display matched one of the designations.",
+								coding.getCode()));
+						return response;
+					}
+				}
+			}
+			if (termMatch != null) {
+				response.addParameter("result", false);
+				response.addParameter("message", format("The code '%s' is valid and the display matched the designation with term '%s', " +
+								"however the language of the designation '%s' did not match any of the languages in the requested display language '%s'.",
+						coding.getCode(), termMatch.getTerm(), termMatch.getLang(), displayLanguage));
+				return response;
+			}
+			response.addParameter("result", false);
+			response.addParameter("message", format("The code '%s' is valid, however the display '%s' did not match any designations.",
+					coding.getCode(), codingDisplay));
+			return response;
+		}
+
+		response.addParameter("result", false);
+		if (codingsToValidate.size() == 1) {
+			Coding coding = codingsToValidate.iterator().next();
+			String codingVersion = coding.getVersion();
+			response.addParameter("message", format("The code '%s' is not valid in CodeSystem '%s'%s.",
+					coding.getCode(), coding.getSystem(), codingVersion != null ? format(" version '%s'", codingVersion) : ""));
+		} else {
+			response.addParameter("message", "None of the codings in the CodeableConcept are valid in this CodeSystem.");
+		}
+		return response;
+	}
+
+	private static boolean versionsMatch(Coding coding, FHIRCodeSystem codeSystem) {
+		return coding.getVersion() == null || coding.getVersion().equals(codeSystem.getEditionUri())
+				|| coding.getVersion().equals(codeSystem.getVersionUri());
 	}
 
 	public Parameters subsumes(FHIRCodeSystem codeSystem, String codeA, String codeB) {

--- a/src/main/java/org/snomed/snowstormlite/service/CodeSystemService.java
+++ b/src/main/java/org/snomed/snowstormlite/service/CodeSystemService.java
@@ -38,53 +38,6 @@ public class CodeSystemService {
 		}
 	}
 
-	public Parameters validateCode(FHIRCodeSystem codeSystem, String code, String display, List<LanguageDialect> languageDialects) {
-		try {
-			Parameters response = new Parameters();
-			response.addParameter(new Parameters.ParametersParameterComponent().setName("system").setValue(new UriType(FHIRConstants.SNOMED_URI)));
-			response.addParameter(new Parameters.ParametersParameterComponent().setName("version").setValue(new StringType(codeSystem.getVersionUri())));
-			if (code != null) {
-				response.addParameter(new Parameters.ParametersParameterComponent().setName("code").setValue(new CodeType(code)));
-			}
-
-			FHIRConcept concept = code != null ? repository.getConcept(code) : null;
-			if (concept == null) {
-				response.addParameter("result", false);
-				response.addParameter("message", String.format("The code '%s' was not found in code system '%s'.", code, FHIRConstants.SNOMED_URI));
-				return response;
-			}
-
-			String preferredTerm = concept.getPT(languageDialects);
-			if (preferredTerm != null) {
-				response.addParameter("display", preferredTerm);
-			}
-
-			// When a display is supplied it must match one of the concept's terms
-			if (display != null && !display.isBlank()) {
-				boolean displayMatches = concept.getDescriptions().stream()
-						.map(FHIRDescription::getTerm)
-						.filter(Objects::nonNull)
-						.anyMatch(term -> term.equalsIgnoreCase(display));
-				if (!displayMatches) {
-					response.addParameter("result", false);
-					response.addParameter("message", String.format(
-							"The code '%s' was found but the display '%s' is not a valid term for it%s.",
-							code, display, preferredTerm != null ? String.format(" (a valid display is '%s')", preferredTerm) : ""));
-					return response;
-				}
-			}
-
-			response.addParameter("result", true);
-			if (!concept.isActive()) {
-				response.addParameter("inactive", true);
-				response.addParameter("message", String.format("The code '%s' is valid but is inactive.", code));
-			}
-			return response;
-		} catch (IOException e) {
-			throw exception("Failed to load concept.", OperationOutcome.IssueType.EXCEPTION, 500, e);
-		}
-	}
-
 	public List<GraphNode> loadHierarchyPart(String system, String version, Collection<String> codes, boolean includeTerms) throws IOException {
 		FHIRCodeSystem codeSystem = repository.getCodeSystem();
 		if (!FHIRConstants.SNOMED_URI.equals(system)) {
@@ -192,8 +145,9 @@ public class CodeSystemService {
 				return response;
 			}
 			response.addParameter("result", false);
-			response.addParameter("message", format("The code '%s' is valid, however the display '%s' did not match any designations.",
-					coding.getCode(), codingDisplay));
+			String preferredTerm = concept.getPT(languageDialects);
+			response.addParameter("message", format("The code '%s' is valid, however the display '%s' did not match any designations%s.",
+					coding.getCode(), codingDisplay, preferredTerm != null ? format(" (a valid display is '%s')", preferredTerm) : ""));
 			return response;
 		}
 

--- a/src/main/resources/fhir/css/dashboard.css
+++ b/src/main/resources/fhir/css/dashboard.css
@@ -312,6 +312,20 @@ th.sortable {
 	cursor: pointer;
 }
 
+.snomed-mini-language-cluster {
+	width: auto;
+	max-width: 10rem;
+}
+
+.snomed-mini-language-select {
+	min-width: 4.5rem;
+	max-width: 6.5rem;
+	background-color: #f8f9fa;
+	border-color: #dee2e6 !important;
+	color: #495057;
+	cursor: pointer;
+}
+
 .snomed-mini-pane-divider {
 	flex: 0 0 10px;
 	width: 10px;

--- a/src/main/resources/fhir/index.html
+++ b/src/main/resources/fhir/index.html
@@ -611,7 +611,19 @@
 				<div class="snomed-taxonomy-pane flex-shrink-0"
 					:class="{ 'snomed-taxonomy-pane--sized': snomedTaxonomyPaneWidthPx != null }"
 					:style="snomedTaxonomyPaneInlineStyle">
-					<div class="fw-semibold small text-muted mb-2">Taxonomy</div>
+					<div class="d-flex align-items-center justify-content-between mb-2">
+						<span class="fw-semibold small text-muted">Taxonomy</span>
+						<div class="btn-group btn-group-sm" role="group" aria-label="Taxonomy term display">
+							<input type="radio" class="btn-check" id="snomedTermModeFsn" value="fsn"
+								x-model="snomedTaxonomyTermMode" @change="onSnomedTaxonomyTermModeChange()">
+							<label class="btn btn-outline-secondary py-0 px-2" for="snomedTermModeFsn"
+								title="Fully specified name (bulk lookup)">FSN</label>
+							<input type="radio" class="btn-check" id="snomedTermModePt" value="pt"
+								x-model="snomedTaxonomyTermMode" @change="onSnomedTaxonomyTermModeChange()">
+							<label class="btn btn-outline-secondary py-0 px-2" for="snomedTermModePt"
+								title="Preferred term in the selected language (from expansion)">PT</label>
+						</div>
+					</div>
 					<div class="snomed-panel border rounded p-2 bg-white">
 						<template x-if="snomedHierarchyError">
 							<div class="alert alert-warning py-2 small mb-2" x-text="snomedHierarchyError"></div>
@@ -665,9 +677,9 @@
 											<button type="button"
 												class="btn btn-link btn-sm text-start text-decoration-none p-0 snomed-tree-label flex-grow-1 min-w-0 text-break"
 												:class="{ 'text-muted text-decoration-line-through': row.node.inactive }"
-												:aria-label="'SNOMED ' + row.node.code + ': ' + (row.node.displayLabel || row.node.display)"
+												:aria-label="'SNOMED ' + row.node.code + ': ' + snomedNodeLabel(row.node)"
 												@click="selectSnomedConcept(row.node.code)">
-												<span x-text="row.node.displayLabel || row.node.display"></span>
+												<span x-text="snomedNodeLabel(row.node)"></span>
 												<template x-if="row.node.inactive">
 													<span class="badge bg-secondary ms-1">inactive</span>
 												</template>

--- a/src/main/resources/fhir/index.html
+++ b/src/main/resources/fhir/index.html
@@ -495,7 +495,20 @@
 				<div class="col-12 col-lg-auto d-flex flex-wrap align-items-center justify-content-lg-end gap-2">
 					<div class="snomed-mini-pill-muted small text-muted border rounded px-2 py-1"
 						x-text="snomedEditionChromeText"></div>
-					<div class="snomed-mini-pill-muted small text-muted border rounded px-2 py-1" x-text="snomedChromeLanguage"></div>
+					<div class="input-group input-group-sm snomed-mini-language-cluster flex-nowrap">
+						<label class="input-group-text py-1 text-muted border-end-0 mb-0" for="snomedDisplayLanguageSelect">lang:</label>
+						<select id="snomedDisplayLanguageSelect"
+							class="form-select form-select-sm snomed-mini-language-select border-start-0"
+							x-model="snomedDisplayLanguage"
+							@change="onSnomedDisplayLanguageChange()"
+							:disabled="!snomedAvailableLanguages.length"
+							:title="'Display language for SNOMED terms (displayLanguage)'"
+							aria-label="SNOMED display language">
+							<template x-for="lang in snomedAvailableLanguages" :key="'snomed-lang-' + lang">
+								<option :value="lang" x-text="lang"></option>
+							</template>
+						</select>
+					</div>
 					<button type="button" class="btn btn-outline-secondary btn-sm" title="Reload browser"
 						@click="refreshSnomedBrowser()"><i class="bi bi-arrow-clockwise"></i></button>
 					<a class="btn btn-outline-secondary btn-sm"

--- a/src/main/resources/fhir/js/dashboard.js
+++ b/src/main/resources/fhir/js/dashboard.js
@@ -97,6 +97,8 @@ function createDashboardState() {
 		snomedConceptChildrenExpanded: false,
 		snomedCodeDisplayCache: {},
 		snomedEditionSummaryLine: '—',
+		snomedAvailableLanguages: [],
+		snomedDisplayLanguage: 'en',
 		/** Set after dragging the taxonomy/detail splitter; null uses default flex sizing from CSS */
 		snomedTaxonomyPaneWidthPx: readStoredSnomedTaxonomyPaneWidthPx(),
 		snomedPaneDividerDragging: false

--- a/src/main/resources/fhir/js/dashboard.js
+++ b/src/main/resources/fhir/js/dashboard.js
@@ -9,6 +9,7 @@ import { dashboardSettings } from './dashboard/settings.js';
 import {
 	dashboardSnomedBrowser,
 	readStoredSnomedTaxonomyPaneWidthPx,
+	readStoredSnomedTaxonomyTermMode,
 	snomedBrowserGetters,
 	SNOMED_ROOT_CONCEPT
 } from './dashboard/snomedBrowser.js';
@@ -144,6 +145,7 @@ function createDashboardState() {
 		snomedEditionSummaryLine: '—',
 		snomedAvailableLanguages: [],
 		snomedDisplayLanguage: 'en',
+		snomedTaxonomyTermMode: readStoredSnomedTaxonomyTermMode(),
 		/** Set after dragging the taxonomy/detail splitter; null uses default flex sizing from CSS */
 		snomedTaxonomyPaneWidthPx: readStoredSnomedTaxonomyPaneWidthPx(),
 		snomedPaneDividerDragging: false

--- a/src/main/resources/fhir/js/dashboard/modalDetail.js
+++ b/src/main/resources/fhir/js/dashboard/modalDetail.js
@@ -277,6 +277,8 @@ export const dashboardModalDetail = {
 		const qs = new URLSearchParams();
 		qs.append('url', url);
 		qs.append('_count', '50');
+		const lang = this.snomedDisplayLanguage != null ? String(this.snomedDisplayLanguage).trim() : '';
+		if (lang) qs.append('displayLanguage', lang);
 		window.open(`${this.fhirBaseUrl}/ValueSet/$expand?${qs.toString()}`, '_blank', 'noopener,noreferrer');
 	},
 

--- a/src/main/resources/fhir/js/dashboard/snomedBrowser.js
+++ b/src/main/resources/fhir/js/dashboard/snomedBrowser.js
@@ -23,6 +23,8 @@ const SNOMED_CHILD_PREVIEW_COUNT = 6;
 /** Taxonomy column resize (desktop split layout). */
 const SNOMED_TAXONOMY_PANE_WIDTH_STORAGE_KEY = 'snomed-mini-taxonomy-pane-px';
 const SNOMED_DISPLAY_LANGUAGE_STORAGE_KEY = 'snomed-mini-display-language';
+/** Taxonomy term display: 'fsn' (bulk-lookup FSN) or 'pt' (preferred term from $expand). */
+const SNOMED_TAXONOMY_TERM_MODE_STORAGE_KEY = 'snomed-mini-taxonomy-term-mode';
 const SNOMED_TAXONOMY_PANE_MIN_PX = 180;
 const SNOMED_TAXONOMY_PANE_MAX_PX = 960;
 const SNOMED_DETAIL_PANE_MIN_PX = 220;
@@ -36,6 +38,15 @@ export function readStoredSnomedDisplayLanguage() {
 		return v != null && String(v).trim() !== '' ? String(v).trim() : null;
 	} catch {
 		return null;
+	}
+}
+
+/** Restore the saved taxonomy term mode ('fsn' default, or 'pt'). */
+export function readStoredSnomedTaxonomyTermMode() {
+	try {
+		return localStorage.getItem(SNOMED_TAXONOMY_TERM_MODE_STORAGE_KEY) === 'pt' ? 'pt' : 'fsn';
+	} catch {
+		return 'fsn';
 	}
 }
 
@@ -357,6 +368,7 @@ function createEmptyTreeNode(code, display, inactive = false, pendingHints = fal
 		inactive,
 		sufficientlyDefined: null,
 		displayLabel: null,
+		ptLabel: display || String(code),
 		expandable: null,
 		hierarchyHintPending: pendingHints,
 		expanded: false,
@@ -479,6 +491,8 @@ export function extractSnomedHierarchyHints(parsed, langCode) {
 	return {
 		hasChildren,
 		displayLabel,
+		// Preferred term in the requested display language (the $lookup/$expand 'display'); shown in PT mode.
+		pt: parsed.display || parsed.code || '',
 		inactive: typeof inactive === 'boolean' ? inactive : undefined,
 		sufficientlyDefined
 	};
@@ -487,6 +501,7 @@ export function extractSnomedHierarchyHints(parsed, langCode) {
 function applyHierarchyHintsToNode(node, hints) {
 	node.expandable = hints.hasChildren;
 	node.displayLabel = hints.displayLabel || node.display;
+	node.ptLabel = hints.pt || node.display || node.ptLabel;
 	node.hierarchyHintPending = false;
 	if (typeof hints.inactive === 'boolean') {
 		node.inactive = hints.inactive;
@@ -500,6 +515,7 @@ function fallbackHierarchyHints(node) {
 	return {
 		hasChildren: true,
 		displayLabel: node.display,
+		pt: node.ptLabel || node.display,
 		inactive: node.inactive
 	};
 }
@@ -651,12 +667,18 @@ export const dashboardSnomedBrowser = {
 
 	async snomedPostBatchBundle(bundleObj) {
 		const root = `${String(this.fhirBaseUrl || '').replace(/\/$/, '')}/`;
+		const headers = {
+			Accept: 'application/fhir+json',
+			'Content-Type': 'application/fhir+json'
+		};
+		// The per-entry displayLanguage query param is not bound on batched $lookup; the server falls back to the
+		// request Accept-Language header. All entries in one batch share the selected language, so set it here —
+		// this makes the looked-up preferred term (PT mode label) honor the toolbar language.
+		const lang = this.snomedDisplayLanguage != null ? String(this.snomedDisplayLanguage).trim() : '';
+		if (lang) headers['Accept-Language'] = lang;
 		const res = await fetchWithTimeout(root, AJAX_TIMEOUT_MS, {
 			method: 'POST',
-			headers: {
-				Accept: 'application/fhir+json',
-				'Content-Type': 'application/fhir+json'
-			},
+			headers,
 			body: JSON.stringify(bundleObj)
 		});
 		const data = await res.json().catch(() => ({}));
@@ -959,6 +981,24 @@ export const dashboardSnomedBrowser = {
 			node.childLoadError = errorMessage(err, 'SNOMED children', res);
 		} finally {
 			node.loading = false;
+		}
+	},
+
+	/** Tree-row label honoring the FSN/PT toggle: PT shows the $expand preferred term, FSN the looked-up FSN. */
+	snomedNodeLabel(node) {
+		if (!node) return '';
+		const code = String(node.code || '');
+		const label = this.snomedTaxonomyTermMode === 'pt'
+			? node.ptLabel || node.display || node.displayLabel
+			: node.displayLabel || node.display;
+		return String(label || code || '').trim() || code;
+	},
+
+	onSnomedTaxonomyTermModeChange() {
+		try {
+			localStorage.setItem(SNOMED_TAXONOMY_TERM_MODE_STORAGE_KEY, String(this.snomedTaxonomyTermMode || 'fsn'));
+		} catch {
+			/* ignore */
 		}
 	},
 

--- a/src/main/resources/fhir/js/dashboard/snomedBrowser.js
+++ b/src/main/resources/fhir/js/dashboard/snomedBrowser.js
@@ -200,13 +200,27 @@ function breadcrumbDisplayForNode(node) {
 	return String(node.displayLabel || node.display || node.code || '').trim() || String(node.code);
 }
 
-function breadcrumbFsntOrDisplay(detail) {
-	if (!detail) return '';
-	const designations = detail.designations || [];
-	const fsn = designations.find(d => {
+/**
+ * Pick the FSN designation, preferring the one whose language matches the selected display language
+ * (two-letter compare, SNOMED dialect tags collapsed). Falls back to the first FSN if none matches.
+ */
+function pickFsnDesignation(designations, langCode) {
+	const fsns = (Array.isArray(designations) ? designations : []).filter(d => {
 		const u = String(d.use ?? '');
 		return u.includes('Fully specified name') || u.includes(SNOMED_FSN_DESCRIPTION_TYPE_ID);
 	});
+	if (!fsns.length) return null;
+	const want = snomedMiniBrowserTwoLetterLangCode(langCode);
+	if (want) {
+		const match = fsns.find(d => snomedMiniBrowserTwoLetterLangCode(d.language) === want);
+		if (match) return match;
+	}
+	return fsns[0];
+}
+
+function breadcrumbFsntOrDisplay(detail, langCode) {
+	if (!detail) return '';
+	const fsn = pickFsnDesignation(detail.designations, langCode);
 	const fromDesig = fsn && String(fsn.value || '').trim();
 	return fromDesig || String(detail.display || detail.code || '').trim();
 }
@@ -227,11 +241,11 @@ function snomedMiniBrowserTwoLetterLangCode(langTag) {
  * Non-FSN designation terms grouped by two-letter language code (dialect tags merged).
  * Each row is one language line for the concept hero / synonyms area.
  */
-function termsByLanguageLinesFromDetail(detail, maxPerLanguage = 48) {
+function termsByLanguageLinesFromDetail(detail, langCode, maxPerLanguage = 48) {
 	const designations = detail?.designations;
 	if (!Array.isArray(designations) || !designations.length) return [];
 
-	const heroLc = breadcrumbFsntOrDisplay(detail).toLocaleLowerCase();
+	const heroLc = breadcrumbFsntOrDisplay(detail, langCode).toLocaleLowerCase();
 	/** two-letter code or empty when tag missing */
 	const buckets = new Map();
 
@@ -452,12 +466,8 @@ export function parseLookupParameters(input) {
 	return out;
 }
 
-export function extractSnomedHierarchyHints(parsed) {
-	const designations = parsed.designations || [];
-	const fsnDesig = designations.find(d => {
-		const u = String(d.use ?? '');
-		return u.includes('Fully specified name') || u.includes(SNOMED_FSN_DESCRIPTION_TYPE_ID);
-	});
+export function extractSnomedHierarchyHints(parsed, langCode) {
+	const fsnDesig = pickFsnDesignation(parsed.designations, langCode);
 	const displayLabel = (fsnDesig && fsnDesig.value) || parsed.display || parsed.code || '';
 	const hasChildren = Array.isArray(parsed.children) && parsed.children.length > 0;
 	const inactive = parsed.inactive;
@@ -515,13 +525,13 @@ function batchLookupBundleBody(codes, displayLanguage) {
 	};
 }
 
-function parseBatchLookupHintMap(bundleJson) {
+function parseBatchLookupHintMap(bundleJson, langCode) {
 	const map = new Map();
 	for (const e of bundleJson.entry || []) {
 		const r = e.resource;
 		if (r && r.resourceType === 'Parameters') {
 			const parsed = parseLookupParameters(r);
-			if (parsed.code) map.set(String(parsed.code), extractSnomedHierarchyHints(parsed));
+			if (parsed.code) map.set(String(parsed.code), extractSnomedHierarchyHints(parsed, langCode));
 		}
 	}
 	return map;
@@ -548,11 +558,11 @@ export const snomedBrowserGetters = {
 	},
 
 	get snomedHeroFsn() {
-		return breadcrumbFsntOrDisplay(this.snomedDetail);
+		return breadcrumbFsntOrDisplay(this.snomedDetail, this.snomedDisplayLanguage);
 	},
 
 	get snomedHeroTermsByLanguage() {
-		return termsByLanguageLinesFromDetail(this.snomedDetail);
+		return termsByLanguageLinesFromDetail(this.snomedDetail, this.snomedDisplayLanguage);
 	},
 
 	get snomedHeroSufficiencyMarker() {
@@ -702,7 +712,7 @@ export const dashboardSnomedBrowser = {
 				for (const n of chunk) applyHierarchyHintsToNode(n, fallbackHierarchyHints(n));
 				continue;
 			}
-			const hintsMap = parseBatchLookupHintMap(bundleResp);
+			const hintsMap = parseBatchLookupHintMap(bundleResp, this.snomedDisplayLanguage);
 			for (const n of chunk) {
 				const h = hintsMap.get(String(n.code)) || fallbackHierarchyHints(n);
 				applyHierarchyHintsToNode(n, h);
@@ -796,7 +806,7 @@ export const dashboardSnomedBrowser = {
 		}
 		try {
 			const lookedUp = await this.snomedLookupConcept(v.id);
-			const hints = extractSnomedHierarchyHints(lookedUp);
+			const hints = extractSnomedHierarchyHints(lookedUp, this.snomedDisplayLanguage);
 			const root = createEmptyTreeNode(v.id, lookedUp.display || v.id, lookedUp.inactive === true, false);
 			applyHierarchyHintsToNode(root, hints);
 			this.snomedTreeRoot = root;
@@ -1224,7 +1234,7 @@ export const dashboardSnomedBrowser = {
 			label: breadcrumbDisplayForNode(root)
 		};
 		const curLab =
-			String(this.snomedDetail?.code) === sel ? breadcrumbFsntOrDisplay(this.snomedDetail) || sel : sel;
+			String(this.snomedDetail?.code) === sel ? breadcrumbFsntOrDisplay(this.snomedDetail, this.snomedDisplayLanguage) || sel : sel;
 		if (sel === rootCr.code) {
 			this.snomedBreadcrumbTrail = [rootCr];
 			return;
@@ -1260,7 +1270,7 @@ export const dashboardSnomedBrowser = {
 				return { code: codeStr, label: rootCr.label };
 			}
 			if (codeStr === sel && String(detail?.code) === sel) {
-				const fromDetail = breadcrumbFsntOrDisplay(detail);
+				const fromDetail = breadcrumbFsntOrDisplay(detail, this.snomedDisplayLanguage);
 				return { code: codeStr, label: (fromDetail && String(fromDetail).trim()) || curLab };
 			}
 			const gn = byCode.get(codeStr);

--- a/src/main/resources/fhir/js/dashboard/snomedBrowser.js
+++ b/src/main/resources/fhir/js/dashboard/snomedBrowser.js
@@ -1,5 +1,6 @@
 import { AJAX_TIMEOUT_MS } from './constants.js';
 import { fetchWithTimeout, errorMessage } from './http.js';
+import { codeSystemAvailableContentLanguages } from './resourceTransforms.js';
 
 export const SNOMED_SYSTEM_URI = 'http://snomed.info/sct';
 export const SNOMED_ROOT_CONCEPT = '138875005';
@@ -21,11 +22,45 @@ const SNOMED_CHILD_PREVIEW_COUNT = 6;
 
 /** Taxonomy column resize (desktop split layout). */
 const SNOMED_TAXONOMY_PANE_WIDTH_STORAGE_KEY = 'snomed-mini-taxonomy-pane-px';
+const SNOMED_DISPLAY_LANGUAGE_STORAGE_KEY = 'snomed-mini-display-language';
 const SNOMED_TAXONOMY_PANE_MIN_PX = 180;
 const SNOMED_TAXONOMY_PANE_MAX_PX = 960;
 const SNOMED_DETAIL_PANE_MIN_PX = 220;
 
 const FHIR_SNOMED_VERSION_DATE = /^https?:\/\/snomed\.info\/[xs]?sct\/(\d+)\/version\/(\d{8})/;
+
+/** Restore saved display language for the SNOMED mini-browser. */
+export function readStoredSnomedDisplayLanguage() {
+	try {
+		const v = localStorage.getItem(SNOMED_DISPLAY_LANGUAGE_STORAGE_KEY);
+		return v != null && String(v).trim() !== '' ? String(v).trim() : null;
+	} catch {
+		return null;
+	}
+}
+
+/** Pick a display language from loaded edition content, preferring stored choice then English. */
+export function resolveSnomedDisplayLanguage(available, preferred) {
+	const langs = (available || []).map(l => String(l).trim()).filter(Boolean);
+	if (!langs.length) return 'en';
+	const want = preferred != null ? String(preferred).trim() : '';
+	if (want && langs.includes(want)) return want;
+	if (langs.includes('en')) return 'en';
+	return langs[0];
+}
+
+function collectAllLoadedTreeNodes(root) {
+	const out = [];
+	const walk = node => {
+		if (!node) return;
+		out.push(node);
+		if (Array.isArray(node.children)) {
+			for (const c of node.children) walk(c);
+		}
+	};
+	walk(root);
+	return out;
+}
 
 /** Restore saved taxonomy column width for the SNOMED mini-browser split pane. */
 export function readStoredSnomedTaxonomyPaneWidthPx() {
@@ -277,7 +312,7 @@ function flattenContains(contains, out = []) {
 	return out;
 }
 
-function expandParametersBody(url, filter, offset, count) {
+function expandParametersBody(url, filter, offset, count, displayLanguage) {
 	const parameter = [
 		{ name: 'url', valueUri: url },
 		{ name: 'count', valueInteger: count },
@@ -285,6 +320,10 @@ function expandParametersBody(url, filter, offset, count) {
 	];
 	if (filter != null && String(filter).trim() !== '') {
 		parameter.push({ name: 'filter', valueString: String(filter).trim() });
+	}
+	const lang = displayLanguage != null ? String(displayLanguage).trim() : '';
+	if (lang) {
+		parameter.push({ name: 'displayLanguage', valueString: lang });
 	}
 	return JSON.stringify({ resourceType: 'Parameters', parameter });
 }
@@ -461,14 +500,16 @@ function chunkArray(arr, size) {
 	return chunks;
 }
 
-function batchLookupBundleBody(codes) {
+function batchLookupBundleBody(codes, displayLanguage) {
+	const lang = displayLanguage != null ? String(displayLanguage).trim() : '';
+	const langQs = lang ? `&displayLanguage=${encodeURIComponent(lang)}` : '';
 	return {
 		resourceType: 'Bundle',
 		type: 'batch',
 		entry: codes.map(code => ({
 			request: {
 				method: 'GET',
-				url: `CodeSystem/$lookup?system=${encodeURIComponent(SNOMED_SYSTEM_URI)}&code=${encodeURIComponent(String(code))}`
+				url: `CodeSystem/$lookup?system=${encodeURIComponent(SNOMED_SYSTEM_URI)}&code=${encodeURIComponent(String(code))}${langQs}`
 			}
 		}))
 	};
@@ -504,10 +545,6 @@ export const snomedBrowserGetters = {
 	get snomedEditionChromeText() {
 		const s = this.snomedEditionSummaryLine;
 		return s && String(s).trim().length ? s : 'SNOMED CT edition';
-	},
-
-	get snomedChromeLanguage() {
-		return 'FSN · en-US';
 	},
 
 	get snomedHeroFsn() {
@@ -585,7 +622,7 @@ export const dashboardSnomedBrowser = {
 				Accept: 'application/fhir+json',
 				'Content-Type': 'application/fhir+json'
 			},
-			body: expandParametersBody(url, filter, offset, count)
+			body: expandParametersBody(url, filter, offset, count, this.snomedDisplayLanguage)
 		});
 		const data = await res.json().catch(() => ({}));
 		if (!res.ok) {
@@ -660,7 +697,7 @@ export const dashboardSnomedBrowser = {
 			const codes = chunk.map(n => n.code);
 			let bundleResp;
 			try {
-				bundleResp = await this.snomedPostBatchBundle(batchLookupBundleBody(codes));
+				bundleResp = await this.snomedPostBatchBundle(batchLookupBundleBody(codes, this.snomedDisplayLanguage));
 			} catch {
 				for (const n of chunk) applyHierarchyHintsToNode(n, fallbackHierarchyHints(n));
 				continue;
@@ -678,18 +715,22 @@ export const dashboardSnomedBrowser = {
 			system: SNOMED_SYSTEM_URI,
 			code: String(code)
 		});
+		const lang = this.snomedDisplayLanguage != null ? String(this.snomedDisplayLanguage).trim() : '';
+		if (lang) qs.set('displayLanguage', lang);
 		let res = await fetchWithTimeout(`${this.fhirBaseUrl}/CodeSystem/$lookup?${qs}`, AJAX_TIMEOUT_MS, {
 			method: 'GET',
 			headers: { Accept: 'application/fhir+json' }
 		});
 		let data = await res.json().catch(() => ({}));
 		if (res.status === 405 || !res.ok) {
+			const parameter = [
+				{ name: 'system', valueUri: SNOMED_SYSTEM_URI },
+				{ name: 'code', valueCode: String(code) }
+			];
+			if (lang) parameter.push({ name: 'displayLanguage', valueString: lang });
 			const body = JSON.stringify({
 				resourceType: 'Parameters',
-				parameter: [
-					{ name: 'system', valueUri: SNOMED_SYSTEM_URI },
-					{ name: 'code', valueCode: String(code) }
-				]
+				parameter
 			});
 			res = await fetchWithTimeout(`${this.fhirBaseUrl}/CodeSystem/$lookup`, AJAX_TIMEOUT_MS, {
 				method: 'POST',
@@ -744,7 +785,7 @@ export const dashboardSnomedBrowser = {
 	},
 
 	async initSnomedBrowserTab() {
-		this.loadSnomedEditionSummary();
+		await this.loadSnomedEditionSummary();
 		this.snomedHierarchyError = null;
 		const v = this.validateSnomedConceptId(this.snomedScopeConceptId || SNOMED_ROOT_CONCEPT);
 		if (!v.ok) {
@@ -991,7 +1032,9 @@ export const dashboardSnomedBrowser = {
 
 			try {
 				for (const chunk of chunkArray(codes, BATCH_LOOKUP_CHUNK)) {
-					const bundleResp = await this.snomedPostBatchBundle(batchLookupBundleBody(chunk));
+					const bundleResp = await this.snomedPostBatchBundle(
+						batchLookupBundleBody(chunk, this.snomedDisplayLanguage)
+					);
 					const rowMap = parseBatchDisplayMap(bundleResp);
 					for (const id of chunk) {
 						const pt = rowMap.get(String(id));
@@ -1100,8 +1143,64 @@ export const dashboardSnomedBrowser = {
 				datePart = `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`;
 			}
 			this.snomedEditionSummaryLine = datePart ? `${title} · ${datePart}` : `${title}`;
+
+			let langs = codeSystemAvailableContentLanguages(cs);
+			if (!langs.length && cs.id) {
+				const detailRes = await fetchWithTimeout(
+					`${this.fhirBaseUrl}/CodeSystem/${encodeURIComponent(cs.id)}`,
+					AJAX_TIMEOUT_MS,
+					{ headers: { Accept: 'application/fhir+json' } }
+				);
+				if (detailRes.ok) {
+					const detail = await detailRes.json().catch(() => ({}));
+					langs = codeSystemAvailableContentLanguages(detail);
+				}
+			}
+			this.snomedAvailableLanguages = langs.length ? langs : ['en'];
+			this.snomedDisplayLanguage = resolveSnomedDisplayLanguage(
+				this.snomedAvailableLanguages,
+				readStoredSnomedDisplayLanguage()
+			);
 		} catch {
 			this.snomedEditionSummaryLine = 'SNOMED CT';
+			this.snomedAvailableLanguages = ['en'];
+			this.snomedDisplayLanguage = resolveSnomedDisplayLanguage(['en'], readStoredSnomedDisplayLanguage());
+		}
+	},
+
+	async onSnomedDisplayLanguageChange() {
+		try {
+			localStorage.setItem(SNOMED_DISPLAY_LANGUAGE_STORAGE_KEY, String(this.snomedDisplayLanguage || ''));
+		} catch {
+			/* ignore */
+		}
+		await this.reloadSnomedBrowserContentForLanguage();
+	},
+
+	async reloadSnomedBrowserContentForLanguage() {
+		const selected = this.snomedSelectedCode;
+		const searchQ = (this.snomedSearchQuery || '').trim();
+
+		this.snomedCodeDisplayCache = {};
+
+		if (this.snomedTreeRoot) {
+			const nodes = collectAllLoadedTreeNodes(this.snomedTreeRoot);
+			for (const n of nodes) {
+				n.hierarchyHintPending = true;
+				n.displayLabel = null;
+				n.expandable = null;
+			}
+			await this.enrichSnomedNodesBatch(nodes);
+		}
+
+		void this.loadSnomedSearchScopeOptions();
+
+		if (searchQ.length >= SNOMED_SEARCH_MIN_CHARS) {
+			await this.runSnomedSearch();
+		}
+
+		if (selected) {
+			await this.selectSnomedConcept(selected);
 		}
 	},
 
@@ -1182,7 +1281,9 @@ export const dashboardSnomedBrowser = {
 		const merged = { ...this.snomedCodeDisplayCache };
 		try {
 			for (const chunk of chunkArray(want, BATCH_LOOKUP_CHUNK)) {
-				const bundleResp = await this.snomedPostBatchBundle(batchLookupBundleBody(chunk));
+				const bundleResp = await this.snomedPostBatchBundle(
+					batchLookupBundleBody(chunk, this.snomedDisplayLanguage)
+				);
 				const partMap = parseBatchDisplayMap(bundleResp);
 				for (const [k, v] of partMap) {
 					if (v != null && String(v).trim().length) merged[String(k)] = String(v).trim();

--- a/src/test/java/org/snomed/snowstormlite/service/CodeSystemServiceTest.java
+++ b/src/test/java/org/snomed/snowstormlite/service/CodeSystemServiceTest.java
@@ -1,5 +1,6 @@
 package org.snomed.snowstormlite.service;
 
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Parameters;
 import org.ihtsdo.otf.snomedboot.ReleaseImportException;
 import org.junit.jupiter.api.AfterEach;
@@ -8,13 +9,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.snomed.snowstormlite.TestConfig;
 import org.snomed.snowstormlite.TestService;
 import org.snomed.snowstormlite.domain.FHIRCodeSystem;
+import org.snomed.snowstormlite.domain.LanguageDialect;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.snomed.snowstormlite.fhir.FHIRConstants.SNOMED_URI;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = TestConfig.class)
@@ -28,6 +35,84 @@ class CodeSystemServiceTest {
 
 	@Autowired
 	private TestService testService;
+
+	@Test
+	void testValidateCodeWithValidCode() throws IOException, ReleaseImportException {
+		testService.importRF2Int();
+
+		FHIRCodeSystem codeSystem = codeSystemRepository.getCodeSystem();
+		assertNotNull(codeSystem);
+
+		Set<Coding> codings = Collections.singleton(new Coding(SNOMED_URI, "404684003", null));
+		Parameters result = codeSystemService.validateCode(codeSystem, codings, List.of(), null);
+
+		assertEquals("true", getParameterValue(result, "result"));
+		assertEquals("404684003", getParameterValue(result, "code"));
+		assertEquals(SNOMED_URI, getParameterValue(result, "system"));
+		assertEquals("Clinical finding", getParameterValue(result, "display"));
+		assertEquals("false", getParameterValue(result, "inactive"));
+	}
+
+	@Test
+	void testValidateCodeWithInvalidCode() throws IOException, ReleaseImportException {
+		testService.importRF2Int();
+
+		FHIRCodeSystem codeSystem = codeSystemRepository.getCodeSystem();
+		Set<Coding> codings = Collections.singleton(new Coding(SNOMED_URI, "99999999", null));
+		Parameters result = codeSystemService.validateCode(codeSystem, codings, List.of(), null);
+
+		assertEquals("false", getParameterValue(result, "result"));
+		assertTrue(getParameterValue(result, "message").contains("99999999"));
+	}
+
+	@Test
+	void testValidateCodeWithMatchingDisplay() throws IOException, ReleaseImportException {
+		testService.importRF2Int();
+
+		FHIRCodeSystem codeSystem = codeSystemRepository.getCodeSystem();
+		Set<Coding> codings = Collections.singleton(new Coding(SNOMED_URI, "313005", "Déjà vu"));
+		Parameters result = codeSystemService.validateCode(codeSystem, codings, List.of(new LanguageDialect("en", null)), "en");
+
+		assertEquals("true", getParameterValue(result, "result"));
+		assertTrue(getParameterValue(result, "message").contains("display matched"));
+	}
+
+	@Test
+	void testValidateCodeWithNonMatchingDisplay() throws IOException, ReleaseImportException {
+		testService.importRF2Int();
+
+		FHIRCodeSystem codeSystem = codeSystemRepository.getCodeSystem();
+		Set<Coding> codings = Collections.singleton(new Coding(SNOMED_URI, "313005", "Wrong display"));
+		Parameters result = codeSystemService.validateCode(codeSystem, codings, List.of(new LanguageDialect("en", null)), "en");
+
+		assertEquals("false", getParameterValue(result, "result"));
+		assertTrue(getParameterValue(result, "message").contains("did not match any designations"));
+	}
+
+	@Test
+	void testValidateCodeWithUnknownSystem() throws IOException, ReleaseImportException {
+		testService.importRF2Int();
+
+		FHIRCodeSystem codeSystem = codeSystemRepository.getCodeSystem();
+		Set<Coding> codings = Collections.singleton(new Coding("http://loinc.org", "1000-9", null));
+		Parameters result = codeSystemService.validateCode(codeSystem, codings, List.of(), null);
+
+		assertEquals("false", getParameterValue(result, "result"));
+		assertTrue(getParameterValue(result, "message").contains("not known"));
+	}
+
+	@Test
+	void testValidateCodeWithCodeableConcept() throws IOException, ReleaseImportException {
+		testService.importRF2Int();
+
+		FHIRCodeSystem codeSystem = codeSystemRepository.getCodeSystem();
+		Set<Coding> codings = new LinkedHashSet<>();
+		codings.add(new Coding("http://loinc.org", "1000-9", null));
+		codings.add(new Coding(SNOMED_URI, "404684003", null));
+		Parameters result = codeSystemService.validateCode(codeSystem, codings, List.of(), null);
+
+		assertEquals("true", getParameterValue(result, "result"));
+	}
 
 	@Test
 	void testSubsumesOperation() throws IOException, ReleaseImportException {

--- a/src/test/java/org/snomed/snowstormlite/service/CodeSystemServiceTest.java
+++ b/src/test/java/org/snomed/snowstormlite/service/CodeSystemServiceTest.java
@@ -86,7 +86,11 @@ class CodeSystemServiceTest {
 		Parameters result = codeSystemService.validateCode(codeSystem, codings, List.of(new LanguageDialect("en", null)), "en");
 
 		assertEquals("false", getParameterValue(result, "result"));
-		assertTrue(getParameterValue(result, "message").contains("did not match any designations"));
+		String message = getParameterValue(result, "message");
+		assertTrue(message.contains("did not match any designations"), message);
+		// The mismatch message should hint at a valid display (the concept's preferred term).
+		assertTrue(message.contains("a valid display is"), message);
+		assertTrue(message.contains("Déjà vu"), message);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
Dashboard, syndication, and SNOMED mini-browser enhancements. Merges current `develop` and consolidates the duplicated `$validate-code` onto develop's richer implementation.

### Syndication / import
- Import language reference sets whose filename carries a module prefix (e.g. `der2_cRefset_IPSLanguageSnapshot`) — fixes missing `$expand` display terms for IPS.
- Select the `rel="alternate"` package zip (NCTS/ASF convention) instead of the first zip — fixes the Edición Argentina import that grabbed the wrong package.
- Persist feed URL/credentials to disk and reload on startup (gitignored `syndication-feed-config.properties`), so a configured feed survives a restart.
- Pin `RestTemplate.execute(...)` extractor type so the IDE compiler stops emitting an error stub that silently aborted downloads; catch `Throwable` in the install worker so failures surface as FAILED tasks.

### Dashboard
- Settings page; SNOMED reset (refreshes syndication view + clears install state); delete support; content preview.
- ValueSet/ConceptMap upload: show the chosen file name; editable URL/Name on ValueSet upload.
- SNOMED mini-browser: FSN/PT taxonomy toggle; FSN and PT both honor the toolbar display language (incl. fixing batched `$lookup` language via `Accept-Language`); `displayLanguage` added to the ValueSet expand example.

### Code health
- Consolidated duplicate `CodeSystem/$validate-code` onto develop's richer implementation; folded in the "valid display" hint; test updated (9 passing).

## Testing
- `mvn compile` clean; `CodeSystemServiceTest` green.
- Verified end-to-end against a local instance: Argentina edition installs and imports; `$expand`/`$lookup` return language-correct display terms; mini-browser FSN/PT + language switching behave as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
