### PR TITLE
Register MCP Tool Service in Server Configuration

### DIFF
--- a/src/main/java/org/snomed/snowstormlite/mcp/config/McpConfiguration.java
+++ b/src/main/java/org/snomed/snowstormlite/mcp/config/McpConfiguration.java
@@ -2,6 +2,10 @@ package org.snomed.snowstormlite.mcp.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.snomed.snowstormlite.mcp.service.McpToolService;
+import org.springframework.ai.tool.MethodToolCallbackProvider;
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import jakarta.annotation.PostConstruct;
@@ -28,5 +32,12 @@ public class McpConfiguration {
 	@PostConstruct
 	public void init() {
 		log.info("MCP Configuration initialized - SNOMED CT MCP tools available via SSE transport");
+	}
+
+	@Bean
+	public ToolCallbackProvider mcpToolProvider(McpToolService mcpToolService) {
+		return MethodToolCallbackProvider.builder()
+				.toolObjects(mcpToolService)
+				.build();
 	}
 }

--- a/src/main/java/org/snomed/snowstormlite/mcp/config/McpConfiguration.java
+++ b/src/main/java/org/snomed/snowstormlite/mcp/config/McpConfiguration.java
@@ -3,7 +3,7 @@ package org.snomed.snowstormlite.mcp.config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.snomed.snowstormlite.mcp.service.McpToolService;
-import org.springframework.ai.tool.MethodToolCallbackProvider;
+import org.springframework.ai.tool.method.MethodToolCallbackProvider;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
## Summary
This PR fixes an issue where the MCP server fails to expose any tools to clients. By declaring a `ToolCallbackProvider` bean in `McpConfiguration`, we register the `McpToolService` bean so that its `@Tool`-annotated methods are discovered and served over the MCP SSE transport.

## Changes
* **Modified** `McpConfiguration.java`: Added a `@Bean` definition for `ToolCallbackProvider` using `MethodToolCallbackProvider.builder().toolObjects(mcpToolService).build()`.

## Verification Details
* Verified that the warning `No tool methods found in the provided tool objects: []` is resolved when the server starts up.
* The MCP server now successfully lists the following SNOMED CT tools to connecting clients:
  * `lookup_snomed_code`
  * `search_snomed_codes`
  * `validate_snomed_code`
  * `check_snomed_subsumption`

Closes #24 