### PR TITLE
Add optional ECL parameter to 'search_snomed_codes' MCP tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ Snowstorm Lite now supports the Model Context Protocol, allowing AI assistants l
    - Returns: Complete concept details including display name, FSN, descriptions, parents, children, relationships
 
 2. **search_snomed_codes** - Search concepts by code prefix or description text
-   - Parameters: `query` (required), `activeOnly` (optional, default: true), `language` (optional), `limit` (optional, max: 100)
+   - Parameters: `query` (required), `activeOnly` (optional, default: true), `language` (optional), `limit` (optional, max: 100), `ecl` (optional, default: `*` for all concepts)
    - Returns: List of matching concepts with display names and active status
 
 3. **validate_snomed_code** - Verify if a code exists and check its active status

--- a/src/main/java/org/snomed/snowstormlite/mcp/service/McpToolService.java
+++ b/src/main/java/org/snomed/snowstormlite/mcp/service/McpToolService.java
@@ -122,14 +122,15 @@ public class McpToolService {
 	 * @param activeOnly If true, return only active concepts (default: true)
 	 * @param language Language code for display names (default: "en")
 	 * @param limit Maximum number of results to return (default: 20, max: 100)
+	 * @param ecl Optional ECL expression to filter the search scope (default: "*" all concepts)
 	 * @return ConceptSearchResult containing matching concepts with display names and active status
 	 * @throws McpException if search fails
 	 */
-	@Tool(description = "Search SNOMED CT concepts by code prefix or description text. Returns matching concepts with display names and active status")
-	public ConceptSearchResult search_snomed_codes(String query, Boolean activeOnly, String language, Integer limit) {
+	@Tool(description = "Search SNOMED CT concepts by code prefix or description text. Optionally filter by an ECL (Expression Constraint Language) expression; defaults to '*' (all concepts). ECL examples: '< 404684003' (descendants of Clinical finding), '<< 404684003' (self and descendants). Returns matching concepts with display names and active status.")
+	public ConceptSearchResult search_snomed_codes(String query, Boolean activeOnly, String language, Integer limit, String ecl) {
 		try {
-			log.info("Searching SNOMED CT with query: {}, activeOnly: {}, language: {}, limit: {}",
-					query, activeOnly, language, limit);
+			log.info("Searching SNOMED CT with query: {}, activeOnly: {}, language: {}, limit: {}, ecl: {}",
+					query, activeOnly, language, limit, ecl);
 
 			// Default parameters
 			if (language == null || language.isEmpty()) {
@@ -148,8 +149,11 @@ public class McpToolService {
 			List<LanguageDialect> dialects = createLanguageDialects(language);
 
 			// Build implicit ValueSet for search
-			// Use ECL: * for all concepts
-			String valueSetUrl = "http://snomed.info/sct?fhir_vs=ecl/*";
+			if (ecl == null || ecl.isBlank()) {
+				// Use ECL: * for all concepts
+				ecl = "*";
+			}
+			String valueSetUrl = "http://snomed.info/sct?fhir_vs=ecl/" + ecl;
 
 			// Use ValueSetService to perform search
 			ValueSet expanded = valueSetService.expand(

--- a/src/test/java/org/snomed/snowstormlite/mcp/service/McpToolServiceTest.java
+++ b/src/test/java/org/snomed/snowstormlite/mcp/service/McpToolServiceTest.java
@@ -87,7 +87,7 @@ class McpToolServiceTest {
 		String query = "finding";
 
 		// When
-		ConceptSearchResult result = mcpToolService.search_snomed_codes(query, true, "en", 10);
+		ConceptSearchResult result = mcpToolService.search_snomed_codes(query, true, "en", 10, null);
 
 		// Then
 		assertNotNull(result);
@@ -109,7 +109,7 @@ class McpToolServiceTest {
 		String query = "404684003"; // Search by code
 
 		// When
-		ConceptSearchResult result = mcpToolService.search_snomed_codes(query, null, null, null);
+		ConceptSearchResult result = mcpToolService.search_snomed_codes(query, null, null, null, null);
 
 		// Then
 		assertNotNull(result);
@@ -125,7 +125,7 @@ class McpToolServiceTest {
 		Integer largeLimit = 200; // Over max
 
 		// When
-		ConceptSearchResult result = mcpToolService.search_snomed_codes(query, true, "en", largeLimit);
+		ConceptSearchResult result = mcpToolService.search_snomed_codes(query, true, "en", largeLimit, null);
 
 		// Then
 		assertNotNull(result);
@@ -283,11 +283,82 @@ class McpToolServiceTest {
 		String query = "concept";
 
 		// When - search with activeOnly = true
-		ConceptSearchResult activeResult = mcpToolService.search_snomed_codes(query, true, "en", 50);
+		ConceptSearchResult activeResult = mcpToolService.search_snomed_codes(query, true, "en", 50, null);
 
 		// Then - all results should be active
 		for (ConceptSearchResult.ConceptSummary concept : activeResult.getConcepts()) {
 			assertTrue(concept.isActive(), "All concepts should be active when activeOnly=true");
+		}
+	}
+
+	@Test
+	void testSearchWithEclDescendants_FiltersToProperDescendants() {
+		// Searching "finding" within descendants of Clinical finding (404684003)
+		// Should include Déjà vu (313005) as a descendant,
+		// but NOT Clinical finding itself (404684003, excluded by < operator)
+		// and NOT Finding site (363698007, which is an attribute in a different hierarchy)
+		ConceptSearchResult result = mcpToolService.search_snomed_codes("finding", true, "en", 20, "< 404684003");
+
+		assertNotNull(result);
+		assertTrue(result.getTotalResults() > 0);
+
+		java.util.Set<String> conceptIds = result.getConcepts().stream()
+				.map(ConceptSearchResult.ConceptSummary::getConceptId)
+				.collect(java.util.stream.Collectors.toSet());
+
+		assertTrue(conceptIds.contains("313005"), "Should contain Déjà vu (descendant of Clinical finding)");
+		assertFalse(conceptIds.contains("404684003"), "Should NOT contain Clinical finding itself (< is proper descendants)");
+		assertFalse(conceptIds.contains("363698007"), "Should NOT contain Finding site (different hierarchy)");
+	}
+
+	@Test
+	void testSearchWithEclSelfAndDescendants_IncludesSelf() {
+		// Searching "finding" within Clinical finding and its descendants (<<)
+		// Should include both Clinical finding itself and Déjà vu
+		ConceptSearchResult result = mcpToolService.search_snomed_codes("finding", true, "en", 20, "<< 404684003");
+
+		assertNotNull(result);
+		assertTrue(result.getTotalResults() > 0);
+
+		java.util.Set<String> conceptIds = result.getConcepts().stream()
+				.map(ConceptSearchResult.ConceptSummary::getConceptId)
+				.collect(java.util.stream.Collectors.toSet());
+
+		assertTrue(conceptIds.contains("404684003"), "Should contain Clinical finding itself (<< includes self)");
+		assertTrue(conceptIds.contains("313005"), "Should contain Déjà vu (descendant of Clinical finding)");
+		assertFalse(conceptIds.contains("363698007"), "Should NOT contain Finding site (different hierarchy)");
+	}
+
+	@Test
+	void testSearchDefaultEcl_BackwardCompatible() {
+		// Without explicit ECL, defaults to '*' (all concepts) — same as before the change
+		ConceptSearchResult result = mcpToolService.search_snomed_codes("finding", true, "en", 20, null);
+
+		assertNotNull(result);
+		assertTrue(result.getTotalResults() > 0);
+
+		java.util.Set<String> conceptIds = result.getConcepts().stream()
+				.map(ConceptSearchResult.ConceptSummary::getConceptId)
+				.collect(java.util.stream.Collectors.toSet());
+
+		// Should find concepts across all hierarchies (default wildcard behaviour)
+		assertTrue(conceptIds.contains("404684003"), "Should contain Clinical finding");
+		assertTrue(conceptIds.contains("313005"), "Should contain Déjà vu");
+		assertTrue(conceptIds.contains("363698007"), "Should contain Finding site attribute");
+	}
+
+	@Test
+	void testSearchWithEcl_RespectsActiveOnly() {
+		// Combining ECL with activeOnly filter
+		ConceptSearchResult result = mcpToolService.search_snomed_codes("finding", true, "en", 20, "<< 404684003");
+
+		assertNotNull(result);
+		assertFalse(result.getConcepts().isEmpty());
+
+		for (ConceptSearchResult.ConceptSummary concept : result.getConcepts()) {
+			assertTrue(concept.isActive(), "All concepts should be active when activeOnly=true with ECL");
+			assertNotNull(concept.getConceptId());
+			assertNotNull(concept.getDisplay());
 		}
 	}
 


### PR DESCRIPTION
## What changes?

Adds an optional `ecl` (Expression Constraint Language) parameter to the MCP `search_snomed_codes` tool. When omitted, it defaults to `"*"` (all concepts), preserving existing behaviour.

Files modified:
- `mcp/service/McpToolService.java` — added `String ecl` parameter, built dynamically into the implicit ValueSet URL
- `mcp/service/McpToolServiceTest.java` — updated 4 existing test calls, added 4 new ECL tests

Example usage:
```java
search_snomed_codes("migraine", ecl="<< 404684003")  // Clinical finding + descendants
search_snomed_codes("migraine", ecl="< 404684003")   // proper descendants only
search_snomed_codes("migraine")                       // all concepts (unchanged)
```

## Why was it necessary?

Without an ECL parameter, `search_snomed_codes` searches the entire SNOMED CT hierarchy. A search for "COVID" returns vaccine products mixed with clinical findings, disorders, and procedures indiscriminately. Real-world use cases — clinical data entry, terminology binding, AI-driven form filling — require scoping results to a specific domain such as "descendants of Clinical finding" or "descendants of Procedure". The underlying ECL engine already supports this via `ExpressionConstraintLanguageService`; it was simply not exposed through the MCP interface.

## Tests

New test cases:

| Test | ECL | Verifies |
|------|-----|----------|
| `testSearchWithEclDescendants_FiltersToProperDescendants` | `< 404684003` | Proper descendants only, ancestor excluded |
| `testSearchWithEclSelfAndDescendants_IncludesSelf` | `<< 404684003` | Self + descendants included |
| `testSearchDefaultEcl_BackwardCompatible` | `null` | Defaults to `*`, unchanged behaviour |
| `testSearchWithEcl_RespectsActiveOnly` | `<< 404684003` | ECL + activeOnly combined |

Closes #27 